### PR TITLE
basic cat implementation in ATen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 build/
+*.pyc

--- a/src/ATen/Local.cwrap
+++ b/src/ATen/Local.cwrap
@@ -80,11 +80,5 @@
     - TensorList tensors
     - int dim
   aten_custom_call: |
-    size_t inputs_ = tensors_.size();
-    std::vector<${THTensor}*> t_;
-    t_.reserve(inputs_);
-    for (unsigned int i = 0; i < inputs_; ++i) {
-      t_.push_back(tensors_[i]->tensor);
-    }
-    ${THTensor}_catArray(${state,}self_->tensor, t_.data(), inputs_, dim);
+    ${THTensor}_catArray(${state,}self_->tensor, tensors_.data(), tensors_.size(), dim);
 ]]

--- a/src/ATen/Local.cwrap
+++ b/src/ATen/Local.cwrap
@@ -70,3 +70,21 @@
     - THTensor* self
     - THTensor* src
 ]]
+
+[[
+  name: cat
+  variants: [method]
+  return: self
+  arguments:
+    - arg: THTensor* self
+    - TensorList tensors
+    - int dim
+  aten_custom_call: |
+    size_t inputs_ = tensors_.size();
+    std::vector<${THTensor}*> t_;
+    t_.reserve(inputs_);
+    for (unsigned int i = 0; i < inputs_; ++i) {
+      t_.push_back(tensors_[i]->tensor);
+    }
+    ${THTensor}_catArray(${state,}self_->tensor, t_.data(), inputs_, dim);
+]]

--- a/src/ATen/Local.cwrap
+++ b/src/ATen/Local.cwrap
@@ -73,12 +73,12 @@
 
 [[
   name: cat
-  variants: [method]
+  cname: catArray
+  variants: [function]
   return: self
   arguments:
     - arg: THTensor* self
+      output: True
     - TensorList tensors
     - int dim
-  aten_custom_call: |
-    ${THTensor}_catArray(${state,}self_->tensor, tensors_.data(), tensors_.size(), dim);
 ]]

--- a/src/ATen/Utils.h
+++ b/src/ATen/Utils.h
@@ -34,7 +34,7 @@ static inline std::vector<TH*> tensor_list_checked_cast(ArrayRef<TBase> tensors,
     }
     auto result = dynamic_cast<T*>(expr);
     if (result) {
-      casted.push_back(result->tensor);
+      casted[i] = result->tensor;
     } else {
       runtime_error("Expected a Tensor of type %s but found a type %s for sequence element %u "
                     " in sequence argument at position #%d '%s'",

--- a/src/ATen/Utils.h
+++ b/src/ATen/Utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ArrayRef.h"
+
 namespace at {
 
 #define AT_ASSERT(cond, ...) if (! (cond) ) { at::runtime_error(__VA_ARGS__); }
@@ -17,6 +19,29 @@ static inline T* checked_cast(Base* expr, const char * name, int pos) {
     return result;
   runtime_error("Expected object of type %s but found type %s for argument #%d '%s'",
     T::typeString(),expr->type().toString(),pos,name);
+}
+
+template <typename T, typename TBase>
+static inline ArrayRef<T*> tensor_list_checked_cast(ArrayRef<TBase> tensors, const char * name, int pos) {
+  std::vector<T*> casted(tensors.size());
+  for (unsigned int i = 0; i < tensors.size(); ++i) {
+    auto *expr = tensors[i].pImpl;
+    if (!expr) {
+      runtime_error("Expected a Tensor of type %s but found an undefined Tensor for sequence element %u "
+                    " in sequence argument at position #%d '%s'",
+                    T::typeString(),i,pos,name);
+    }
+    auto result = dynamic_cast<T*>(expr);
+    if (result) {
+      casted.push_back(result);
+    } else {
+      runtime_error("Expected a Tensor of type %s but found a type %s for sequence element %u "
+                    " in sequence argument at position #%d '%s'",
+                    T::typeString(),expr->type().toString(),i,pos,name);
+
+    }
+  }
+  return casted;
 }
 
 } // at

--- a/src/ATen/Utils.h
+++ b/src/ATen/Utils.h
@@ -21,9 +21,10 @@ static inline T* checked_cast(Base* expr, const char * name, int pos) {
     T::typeString(),expr->type().toString(),pos,name);
 }
 
-template <typename T, typename TBase>
-static inline ArrayRef<T*> tensor_list_checked_cast(ArrayRef<TBase> tensors, const char * name, int pos) {
-  std::vector<T*> casted(tensors.size());
+// Converts a TensorList (i.e. ArrayRef<Tensor> to the underlying TH* Tensor Pointer)
+template <typename T, typename TBase, typename TH>
+static inline std::vector<TH*> tensor_list_checked_cast(ArrayRef<TBase> tensors, const char * name, int pos) {
+  std::vector<TH*> casted(tensors.size());
   for (unsigned int i = 0; i < tensors.size(); ++i) {
     auto *expr = tensors[i].pImpl;
     if (!expr) {
@@ -33,7 +34,7 @@ static inline ArrayRef<T*> tensor_list_checked_cast(ArrayRef<TBase> tensors, con
     }
     auto result = dynamic_cast<T*>(expr);
     if (result) {
-      casted.push_back(result);
+      casted.push_back(result->tensor);
     } else {
       runtime_error("Expected a Tensor of type %s but found a type %s for sequence element %u "
                     " in sequence argument at position #%d '%s'",

--- a/src/ATen/function_wrapper.py
+++ b/src/ATen/function_wrapper.py
@@ -109,6 +109,7 @@ CHECKED_USE = {
     'THIntegerTensor*': '{}_->tensor',
     'THStorage*': '{}_->storage',
     'THGenerator*': '{}_->generator',
+    'TensorList': "{0}_.data(), {0}_.size()",
 }
 
 ALLOC_WRAP = {
@@ -376,7 +377,8 @@ def create_derived(backend_type_env, declarations):
 
                 # dim() == 0 of all input tensors is and'd to form
                 # the test for whether the output is also a scalar
-                if not arg.get('output') and 'Tensor' in arg['type'] and not scalar_check_is_from_size:
+                if (not arg.get('output') and 'Tensor' in arg['type'] and
+                        'TensorList' not in arg['type'] and not scalar_check_is_from_size):
                     check = '{}.dim() == 0'.format(arg['name'])
                     scalar_check = (check if scalar_check is None
                                     else scalar_check + ' && ' + check)

--- a/src/ATen/function_wrapper.py
+++ b/src/ATen/function_wrapper.py
@@ -99,8 +99,9 @@ CHECKED_CAST = {
     'THStride*': CodeTemplate('THLongStorageView::make(${arg_name},true)'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),
-
+    'TensorList': CodeTemplate('tensor_list_checked_cast<${Tensor}>(${arg_name},"${arg_name}",${arg_pos})'),
 }
+
 CHECKED_USE = {
     'THTensor*': '{}_->tensor',
     'THIndexTensor*': '{}_->tensor',

--- a/src/ATen/function_wrapper.py
+++ b/src/ATen/function_wrapper.py
@@ -99,7 +99,7 @@ CHECKED_CAST = {
     'THStride*': CodeTemplate('THLongStorageView::make(${arg_name},true)'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),
-    'TensorList': CodeTemplate('tensor_list_checked_cast<${Tensor}>(${arg_name},"${arg_name}",${arg_pos})'),
+    'TensorList': CodeTemplate('tensor_list_checked_cast<${Tensor}, Tensor, ${THTensor}>(${arg_name},"${arg_name}",${arg_pos})'),
 }
 
 CHECKED_USE = {

--- a/src/ATen/templates/Type.h
+++ b/src/ATen/templates/Type.h
@@ -80,6 +80,7 @@ enum class TypeID {
 
 
 typedef ArrayRef<int64_t> IntList;
+typedef ArrayRef<Tensor> TensorList;
 
 struct Type {
   explicit Type(Context * context)


### PR DESCRIPTION
Example code generated:

```
const Tensor & CPUByteType::m_cat(const Tensor & self, TensorList tensors, int dim) {
      auto self_ = checked_cast<CPUByteTensor>(self.pImpl,"self",1);
      auto tensors_ = tensor_list_checked_cast<CPUByteTensor>(tensors,"tensors",2);
      size_t inputs_ = tensors_.size();
      std::vector<THByteTensor*> t_;
      t_.reserve(inputs_);
      for (unsigned int i = 0; i < inputs_; ++i) {
        t_.push_back(tensors_[i]->tensor);
      }
      THByteTensor_catArray(self_->tensor, t_.data(), inputs_, dim);
      return self;
  }
```