### PR TITLE
Fix build for CPU only machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ sudo pip install pyyaml
 mkdir build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=/where/you/want # specify your dest directory
+# cmake .. -DNO_CUDA  # for CPU only machines
 make install
 ```
 


### PR DESCRIPTION
I don't know what the intended behavior is, but with this patch NO_CUDA will work, and not setting NO_CUDA results in a strange crash.