### PR TITLE
Support broadcast specifications from cwrap.

### DIFF
--- a/src/ATen/ExpandUtils.h
+++ b/src/ATen/ExpandUtils.h
@@ -21,7 +21,7 @@ inline std::tuple<Tensor, Tensor> expand_inplace(const Tensor &tensor, const Ten
   return std::make_tuple(to_expand1.expand(tensor.sizes()), to_expand2.expand(tensor.sizes()));
 }
 
-inline std::vector<int64_t> infer_size2(IntList a, InstList b) {
+inline std::vector<int64_t> infer_size2(IntList a, IntList b) {
   auto dimsA = a.size();
   auto dimsB = b.size();
   ptrdiff_t ndim = dimsA > dimsB ? dimsA : dimsB;

--- a/src/ATen/ExpandUtils.h
+++ b/src/ATen/ExpandUtils.h
@@ -21,11 +21,11 @@ std::tuple<Tensor, Tensor> expand_inplace(const Tensor &tensor, const Tensor &to
   return std::make_tuple(to_expand1.expand(tensor.sizes()), to_expand2.expand(tensor.sizes()));
 }
 
-std::vector<uint64_t> infer_size2(IntList a, IntList b) {
+std::vector<int64_t> infer_size2(IntList a, IntList b) {
   auto dimsA = a.size();
   auto dimsB = b.size();
   ptrdiff_t ndim = dimsA > dimsB ? dimsA : dimsB;
-  std::vector<uint64_t> expandedSizes(ndim);
+  std::vector<int64_t> expandedSizes(ndim);
 
   for (long i = ndim - 1; i >= 0; --i) {
     long offset = ndim - 1 - i;
@@ -52,7 +52,7 @@ std::tuple<Tensor, Tensor> expand_outplace(const Tensor &to_expand1, const Tenso
   }
 
   auto infer_size = infer_size2(to_expand1.sizes(), to_expand2.sizes());
-  IntList expanded_size(reinterpret_cast<int64_t*>(infer_size.data()), infer_size.size());
+  IntList expanded_size(infer_size);
   return std::make_tuple(to_expand1.expand(expanded_size), to_expand2.expand(expanded_size));
 }
 
@@ -64,9 +64,9 @@ std::tuple<Tensor, Tensor, Tensor> expand_outplace(const Tensor &to_expand1,
   }
 
   auto infer_size12 = infer_size2(to_expand1.sizes(), to_expand2.sizes());
-  IntList expanded_size12(reinterpret_cast<int64_t*>(infer_size12.data()), infer_size12.size());
+  IntList expanded_size12(infer_size12);
   auto infer_size = infer_size2(expanded_size12, to_expand3.sizes());
-  IntList expanded_size(reinterpret_cast<int64_t*>(infer_size.data()), infer_size.size());
+  IntList expanded_size(infer_size);
   return std::make_tuple(to_expand1.expand(expanded_size), to_expand2.expand(expanded_size), to_expand3.expand(expanded_size));
 }
 

--- a/src/ATen/ExpandUtils.h
+++ b/src/ATen/ExpandUtils.h
@@ -5,7 +5,7 @@
 
 namespace at {
 
-std::tuple<Tensor> expand_inplace(const Tensor &tensor, const Tensor &to_expand) {
+inline std::tuple<Tensor> expand_inplace(const Tensor &tensor, const Tensor &to_expand) {
   if (tensor.sizes().equals(to_expand.sizes())) {
     return std::make_tuple(to_expand);
   }
@@ -13,7 +13,7 @@ std::tuple<Tensor> expand_inplace(const Tensor &tensor, const Tensor &to_expand)
   return std::make_tuple(to_expand.expand(tensor.sizes()));
 }
 
-std::tuple<Tensor, Tensor> expand_inplace(const Tensor &tensor, const Tensor &to_expand1, const Tensor &to_expand2) {
+inline std::tuple<Tensor, Tensor> expand_inplace(const Tensor &tensor, const Tensor &to_expand1, const Tensor &to_expand2) {
   if (tensor.sizes().equals(to_expand1.sizes()) && tensor.sizes().equals((to_expand2.sizes()))) {
     return std::make_tuple(to_expand1, to_expand2);
   }
@@ -21,7 +21,7 @@ std::tuple<Tensor, Tensor> expand_inplace(const Tensor &tensor, const Tensor &to
   return std::make_tuple(to_expand1.expand(tensor.sizes()), to_expand2.expand(tensor.sizes()));
 }
 
-std::vector<int64_t> infer_size2(IntList a, IntList b) {
+inline std::vector<int64_t> infer_size2(IntList a, InstList b) {
   auto dimsA = a.size();
   auto dimsB = b.size();
   ptrdiff_t ndim = dimsA > dimsB ? dimsA : dimsB;
@@ -46,13 +46,12 @@ std::vector<int64_t> infer_size2(IntList a, IntList b) {
   return expandedSizes;
 }
 
-std::tuple<Tensor, Tensor> expand_outplace(const Tensor &to_expand1, const Tensor &to_expand2) {
+inline std::tuple<Tensor, Tensor> expand_outplace(const Tensor &to_expand1, const Tensor &to_expand2) {
   if (to_expand1.sizes().equals(to_expand2.sizes())) {
     return std::make_tuple(to_expand1, to_expand2);
   }
 
-  auto infer_size = infer_size2(to_expand1.sizes(), to_expand2.sizes());
-  IntList expanded_size(infer_size);
+  auto expanded_size = infer_size2(to_expand1.sizes(), to_expand2.sizes());
   return std::make_tuple(to_expand1.expand(expanded_size), to_expand2.expand(expanded_size));
 }
 
@@ -63,14 +62,12 @@ std::tuple<Tensor, Tensor, Tensor> expand_outplace(const Tensor &to_expand1,
     return std::make_tuple(to_expand1, to_expand2, to_expand3);
   }
 
-  auto infer_size12 = infer_size2(to_expand1.sizes(), to_expand2.sizes());
-  IntList expanded_size12(infer_size12);
-  auto infer_size = infer_size2(expanded_size12, to_expand3.sizes());
-  IntList expanded_size(infer_size);
+  auto expanded_size12 = infer_size2(to_expand1.sizes(), to_expand2.sizes());
+  auto expanded_size = infer_size2(expanded_size12, to_expand3.sizes());
   return std::make_tuple(to_expand1.expand(expanded_size), to_expand2.expand(expanded_size), to_expand3.expand(expanded_size));
 }
 
-std::tuple<Tensor> expand_size(const Tensor &to_expand, IntList sizes) {
+inline std::tuple<Tensor> expand_size(const Tensor &to_expand, IntList sizes) {
   if(to_expand.sizes().equals(sizes)) {
     return std::make_tuple(to_expand);
   }

--- a/src/ATen/ExpandUtils.h
+++ b/src/ATen/ExpandUtils.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "ATen/Tensor.h"
+#include <sstream>
+
+namespace at {
+
+std::tuple<Tensor> expand_inplace(const Tensor &tensor, const Tensor &to_expand) {
+  if (tensor.sizes().equals(to_expand.sizes())) {
+    return std::make_tuple(to_expand);
+  }
+
+  return std::make_tuple(to_expand.expand(tensor.sizes()));
+}
+
+std::tuple<Tensor, Tensor> expand_inplace(const Tensor &tensor, const Tensor &to_expand1, const Tensor &to_expand2) {
+  if (tensor.sizes().equals(to_expand1.sizes()) && tensor.sizes().equals((to_expand2.sizes()))) {
+    return std::make_tuple(to_expand1, to_expand2);
+  }
+
+  return std::make_tuple(to_expand1.expand(tensor.sizes()), to_expand2.expand(tensor.sizes()));
+}
+
+std::vector<uint64_t> infer_size2(IntList a, IntList b) {
+  auto dimsA = a.size();
+  auto dimsB = b.size();
+  ptrdiff_t ndim = dimsA > dimsB ? dimsA : dimsB;
+  std::vector<uint64_t> expandedSizes(ndim);
+
+  for (long i = ndim - 1; i >= 0; --i) {
+    long offset = ndim - 1 - i;
+    long dimA = dimsA - 1 - offset;
+    long dimB = dimsB - 1 - offset;
+    long sizeA = (dimA >= 0) ? a[dimA] : 1;
+    long sizeB = (dimB >= 0) ? b[dimB] : 1;
+    if (sizeA == sizeB || sizeA == 1 || sizeB == 1) {
+      expandedSizes[i] = std::max(sizeA, sizeB);
+    } else {
+      std::ostringstream oss;
+      oss << "The size of tensor a (" << sizeA << ") must match the size of tensor b ("
+          << sizeB << ") at non-singleton dimension " << i;
+      throw std::runtime_error(oss.str());
+    }
+  }
+
+  return expandedSizes;
+}
+
+std::tuple<Tensor, Tensor> expand_outplace(const Tensor &to_expand1, const Tensor &to_expand2) {
+  if (to_expand1.sizes().equals(to_expand2.sizes())) {
+    return std::make_tuple(to_expand1, to_expand2);
+  }
+
+  auto infer_size = infer_size2(to_expand1.sizes(), to_expand2.sizes());
+  IntList expanded_size(reinterpret_cast<int64_t*>(infer_size.data()), infer_size.size());
+  return std::make_tuple(to_expand1.expand(expanded_size), to_expand2.expand(expanded_size));
+}
+
+std::tuple<Tensor, Tensor, Tensor> expand_outplace(const Tensor &to_expand1,
+                                                   const Tensor &to_expand2,
+                                                   const Tensor &to_expand3) {
+  if (to_expand1.sizes().equals(to_expand2.sizes()) && to_expand1.sizes().equals(to_expand3.sizes())) {
+    return std::make_tuple(to_expand1, to_expand2, to_expand3);
+  }
+
+  auto infer_size12 = infer_size2(to_expand1.sizes(), to_expand2.sizes());
+  IntList expanded_size12(reinterpret_cast<int64_t*>(infer_size12.data()), infer_size12.size());
+  auto infer_size = infer_size2(expanded_size12, to_expand3.sizes());
+  IntList expanded_size(reinterpret_cast<int64_t*>(infer_size.data()), infer_size.size());
+  return std::make_tuple(to_expand1.expand(expanded_size), to_expand2.expand(expanded_size), to_expand3.expand(expanded_size));
+}
+
+std::tuple<Tensor> expand_size(const Tensor &to_expand, IntList sizes) {
+  if(to_expand.sizes().equals(sizes)) {
+    return std::make_tuple(to_expand);
+  }
+
+  return std::make_tuple(to_expand.expand(sizes));
+}
+
+}

--- a/src/ATen/function_wrapper.py
+++ b/src/ATen/function_wrapper.py
@@ -10,7 +10,19 @@ else:
 # temporary things we cannot handle
 EXCLUDE_PATTERN = "bernoulli.*|normal.*|exponential.*|random.*|arange.*"
 # what has to be done to add a Operation ...
-# 1. add virtual dispatch declaration to Type.h and default impl to Type.cpp
+# 1. if broadcasting, add (non-virtual) broadcast declaration to Type.h and definition to Type.cpp and
+#    rename underlying function
+TYPE_METHOD_DECLARATION_BROADCAST = CodeTemplate("""\
+${return_type} ${method_prefix}${api_name}(${formals}) ;
+""")
+TYPE_METHOD_DEFINITION_BROADCAST = CodeTemplate("""\
+${return_type} Type::${method_prefix}${api_name}(${formals}) {
+    Tensor ${broadcast_returns};
+    std::tie(${broadcast_returns}) = ${broadcast_function}(${broadcast_actuals});
+    return ${method_prefix_derived}${api_name}(${broadcast_modified_actuals});
+}
+""")
+# 2. add virtual dispatch declaration to Type.h and default impl to Type.cpp
 TYPE_METHOD_DECLARATION = CodeTemplate("""\
 virtual ${return_type} ${method_prefix}${api_name}(${formals}) ;
 """)
@@ -19,31 +31,31 @@ ${return_type} Type::${method_prefix}${api_name}(${formals}) {
     throw std::runtime_error(std::string("${api_name} is not implemented for type ") + toString());
 }
 """)
-# 2. add virtual override to TypeDerived.h
+# 3. add virtual override to TypeDerived.h
 TYPE_DERIVED_DECLARATION = CodeTemplate("""\
-virtual ${return_type} ${method_prefix}${api_name}(${formals}) override;
+virtual ${return_type} ${method_prefix_derived}${api_name}(${formals}) override;
 """)
-# 3. add override definition to TypeDerived.cpp
+# 4. add override definition to TypeDerived.cpp
 TYPE_DERIVED_DEFINITION = CodeTemplate("""\
-${return_type} ${Type}::${method_prefix}${api_name}(${formals}) {
+${return_type} ${Type}::${method_prefix_derived}${api_name}(${formals}) {
     ${type_definition_body}
 }
 """)
-# 4. add non-virtual declaration to Tensor.h
+# 5. add non-virtual declaration to Tensor.h
 TENSOR_METHOD_DECLARATION = CodeTemplate("""\
 ${return_type} ${api_name}(${method_formals})${const_mark};
 """)
-# 5. add non-virtual declaration to Tensor.cpp
+# 6. add non-virtual declaration to Tensor.cpp
 TENSOR_METHOD_DEFINITION = CodeTemplate("""\
 inline ${return_type} Tensor::${api_name}(${method_formals})${const_mark} {
     return type().${method_prefix}${api_name}(${method_actuals});
 }
 """)
-# 6. add a method declaration in Functions.h
+# 7. add a method declaration in Functions.h
 FUNCTION_DECLARATION = CodeTemplate("""\
 static inline ${return_type} ${api_name}(${formals});
 """)
-# 7. add a method definition in Functions.cpp
+# 8. add a method definition in Functions.cpp
 FUNCTION_DEFINITION = CodeTemplate("""\
 static inline ${return_type} ${api_name}(${formals}) {
     return ${inferred_type}.${api_name}(${actuals});
@@ -57,14 +69,6 @@ ZERO_DIM_CHECK = CodeTemplate("""\
 if(${check_name}.dim() == 0) {
     return static_cast<Type*>(this)->${method_prefix}${api_name}(${zero_dim_actuals});
 }""")
-
-SCALAR_EXPAND = CodeTemplate("""\
-Tensor ${name}__;
-if(${name}_->isScalar()) {
-    ${name}__ = ${name}.expand(${other}.sizes());
-    ${name}_ = static_cast<${Tensor}*>(${name}__.pImpl);
-}
-""")
 
 SPARSE_CHECK = CodeTemplate("""\
 if(${check_name}.type().isSparse()) {
@@ -133,8 +137,8 @@ CHECKED_CAST = {
             'checked_cast<${Backend}IntTensor>(${arg_name}.pImpl,"${arg_name}",${arg_pos}, ${null_okay})'),
     'THStorage*': CodeTemplate('checked_cast<${Storage}>(&${arg_name},"${arg_name}",${arg_pos}, false)'),
     'THGenerator*': CodeTemplate('check_generator(&${arg_name})'),
-    'THSize*': CodeTemplate('THLongStorageView::make(${arg_name},true)'),
-    'THStride*': CodeTemplate('THLongStorageView::make(${arg_name},true)'),
+    'THSize*': CodeTemplate('THLongStorageView::make(${arg_name}, ${zero_dim_to_one})'),
+    'THStride*': CodeTemplate('THLongStorageView::make(${arg_name}, ${zero_dim_to_one})'),
     'real': CodeTemplate('${arg_name}.to${ScalarName}()'),
     'accreal': CodeTemplate('${arg_name}.to${AccScalarName}()'),
     'TensorList': CodeTemplate('tensor_list_checked_cast<${Tensor}, Tensor, '
@@ -276,6 +280,24 @@ def create_generic(top_env, declarations):
     def format_formal(f):
         return '{} {}'.format(f['type'], f['name'])
 
+    def get_broadcast_argument(option):
+        for argument in option['arguments']:
+            if argument.get('broadcast'):
+                return argument
+
+    def get_broadcast_actuals(broadcast_arg, broadcast_inplace, broadcast_dims):
+        if not broadcast_dims:
+            broadcast_actuals = [broadcast_arg['name']] + broadcast_arg['broadcast'].split()[0].split(",")
+        else:
+            broadcast_dims_spec = broadcast_arg['broadcast'].split()[1].split(':')[1].split(',')
+            # generate size call for each dimension
+            broadcast_dims = ([x.split('.')[0] + '.size(' + x.split('.')[1].replace('dim', '') + ')'
+                              for x in broadcast_dims_spec])
+            broadcast_dims_init_list = '{' + ','.join(broadcast_dims) + '}'
+            broadcast_actuals = [broadcast_arg['name'], broadcast_dims_init_list]
+
+        return broadcast_actuals
+
     def process_option(option, output_options):
         option['inplace'] = re.search(
             '(^__i|[^_]_$)', option['api_name']) is not None
@@ -305,10 +327,43 @@ def create_generic(top_env, declarations):
         # another function-only variant can exist without the name colliding
         option['method_prefix'] = 'm_' if is_method and not is_function else ''
         env = nested_dict(option, top_env)
-        top_env['type_method_declarations'].append(
-            TYPE_METHOD_DECLARATION.substitute(env))
-        top_env['type_method_definitions'].append(
-            TYPE_METHOD_DEFINITION.substitute(env))
+
+        broadcast_arg = get_broadcast_argument(option)
+        if broadcast_arg is None:
+            option['method_prefix_derived'] = option['method_prefix']
+            top_env['type_method_declarations'].append(
+                TYPE_METHOD_DECLARATION.substitute(env))
+            top_env['type_method_definitions'].append(
+                TYPE_METHOD_DEFINITION.substitute(env))
+        else:
+            option['method_prefix_derived'] = 's_' + option['method_prefix']
+            same_size_option = option.copy()
+            same_size_option['method_prefix'] = option['method_prefix_derived']
+            same_size_env = nested_dict(same_size_option, top_env)
+            top_env['type_method_declarations_protected'].append(
+                TYPE_METHOD_DECLARATION.substitute(same_size_env))
+            top_env['type_method_definitions'].append(
+                TYPE_METHOD_DEFINITION.substitute(same_size_env))
+
+            broadcast_inplace = 'inplace' in broadcast_arg['broadcast']
+            broadcast_dims = 'dims:' in broadcast_arg['broadcast']
+            option['broadcast_actuals'] = get_broadcast_actuals(broadcast_arg, broadcast_inplace, broadcast_dims)
+            if not broadcast_dims:
+                option['broadcast_returns'] = (["b_" + x for x in option['broadcast_actuals']
+                                               if x != broadcast_arg['name'] or not broadcast_inplace])
+            else:
+                option['broadcast_returns'] = ["b_" + broadcast_arg['name']]
+
+            option['broadcast_function'] = 'expand_' + ('inplace' if broadcast_inplace
+                                                        else 'size' if broadcast_dims else 'outplace')
+            option['broadcast_modified_actuals'] = ['b_' + y if 'b_' + y in option['broadcast_returns'] else y
+                                                    for y in option['actuals']]
+
+            env = nested_dict(option, top_env)
+            top_env['type_method_declarations'].append(
+                TYPE_METHOD_DECLARATION_BROADCAST.substitute(env))
+            top_env['type_method_definitions'].append(
+                TYPE_METHOD_DEFINITION_BROADCAST.substitute(env))
 
         if is_method:
             top_env['tensor_method_declarations'].append(
@@ -480,7 +535,9 @@ def create_derived(backend_type_env, declarations):
 
                     check_cast = CHECKED_CAST[arg['type']].substitute(
                         env, arg_name=arg['name'], arg_pos=count,
-                        null_okay=null_okay)
+                        null_okay=null_okay,
+                        # don't allow expansion to a scalar
+                        zero_dim_to_one='true' if not option['name'] == 'expand' else 'false')
                     body.append("auto {}_ = {};".format(
                         arg['name'], check_cast))
                 if drop_argument(arg, option):
@@ -500,13 +557,6 @@ def create_derived(backend_type_env, declarations):
                 # also special handling where we zero some outputs.
                 if arg.get('cpu_zero', False) and not is_cuda:
                     body.append("{}.zero_();".format(arg['name']))
-
-                # handle scalars that occur on LHS of things like a - b
-                if 'broadcast' in arg and 'inplace' not in arg['broadcast']:
-                    other = arg['broadcast'].split(' ')[0].split(',')[0]
-                    body.append(SCALAR_EXPAND.substitute(env,
-                                                         name=arg['name'],
-                                                         other=other))
 
                 # dim() == 0 of all input tensors is and'd to form
                 # the test for whether the output is also a scalar

--- a/src/ATen/gen.py
+++ b/src/ATen/gen.py
@@ -83,6 +83,7 @@ top_env = {
     'type_headers': [],
     'type_method_declarations': [],
     'type_method_definitions': [],
+    'type_method_declarations_protected': [],
     'tensor_method_declarations': [],
     'tensor_method_definitions': [],
     'function_declarations': [],

--- a/src/ATen/templates/Type.cpp
+++ b/src/ATen/templates/Type.cpp
@@ -3,6 +3,7 @@
 #include "ATen/Storage.h"
 #include "ATen/Scalar.h"
 #include "ATen/SparseTensorRef.h"
+#include "ATen/ExpandUtils.h"
 
 #include <iostream>
 ${type_headers}

--- a/src/ATen/templates/Type.h
+++ b/src/ATen/templates/Type.h
@@ -133,6 +133,7 @@ struct Type {
   ${type_method_declarations}
 protected:
   Context* context;
+  ${type_method_declarations_protected}
 };
 
 

--- a/src/ATen/test/CMakeLists.txt
+++ b/src/ATen/test/CMakeLists.txt
@@ -6,3 +6,6 @@ TARGET_LINK_LIBRARIES(basic ATen)
 
 add_executable(atest atest.cpp)
 target_link_libraries(atest ATen)
+
+add_executable(broadcast_test broadcast_test.cpp)
+target_link_libraries(broadcast_test ATen)

--- a/src/ATen/test/broadcast_test.cpp
+++ b/src/ATen/test/broadcast_test.cpp
@@ -13,14 +13,6 @@ int main() {
     assert(false);
   } catch(std::runtime_error &e) {}
 
-  // can't "expand" a Tensor to  Scalar
-  try {
-    auto tScalar = T.ones({1});
-    tScalar.get()->maybeScalar(true);
-    tScalar.expand({});
-    assert(false);
-  } catch (std::runtime_error &e) {}
-
   // 1) out-place function with 2 args
   {
     // basic
@@ -104,7 +96,7 @@ int main() {
       bScalar.add_(a);
       assert(false);
     } catch(std::runtime_error &e) {}
-    
+
     // error: would have to expand inplace arg
     try {
       auto a = T.randn({1, 5});
@@ -145,7 +137,7 @@ int main() {
       assert(false);
     } catch(std::runtime_error &e) {}
   }
-  
+
   // explicit dim specification
   {
     // basic

--- a/src/ATen/test/broadcast_test.cpp
+++ b/src/ATen/test/broadcast_test.cpp
@@ -1,0 +1,171 @@
+#include "ATen/ATen.h"
+
+using namespace at;
+
+int main() {
+  Type & T = CPU(kFloat);
+
+  // 0) pre-req tests:
+  // can't expand empty tensor
+  try {
+    auto empty = T.randn({0});
+    empty.expand({3});
+    assert(false);
+  } catch(std::runtime_error &e) {}
+
+  // can't "expand" a Tensor to  Scalar
+  try {
+    auto tScalar = T.ones({1});
+    tScalar.get()->maybeScalar(true);
+    tScalar.expand({});
+    assert(false);
+  } catch (std::runtime_error &e) {}
+
+  // 1) out-place function with 2 args
+  {
+    // basic
+    auto a = T.randn({3, 1});
+    auto b = T.randn({5});
+    std::vector<int64_t> expanded_sizes = {3, 5};
+    assert((a + b).equal(a.expand(expanded_sizes) + b.expand(expanded_sizes)));
+
+    // with scalar
+    auto aScalar = T.ones({1});
+    aScalar.get()->maybeScalar(true);
+    b = T.randn({3, 5});
+    assert((aScalar + b).equal(aScalar.expand(b.sizes()) + b.expand(b.sizes())));
+
+    // old fallback behavior yields error
+    try {
+      auto a = T.randn({3, 5});
+      auto b = T.randn({5, 3});
+      a + b;
+      assert(false);
+    } catch (std::runtime_error &e) {}
+
+    // with mismatched sizes
+    try {
+      auto a = T.randn({3, 5});
+      auto b = T.randn({7, 5});
+      a + b;
+      assert(false);
+    } catch (std::runtime_error &e) {}
+  }
+
+  // 2) out-place function with 3 args
+  {
+    // basic
+    auto a = T.randn({3, 1, 1});
+    auto b = T.randn({1, 2, 1});
+    auto c = T.randn({1, 1, 5});
+    std::vector<int64_t> expanded_sizes = {3, 2, 5};
+    assert((a + b + c).equal(a.expand(expanded_sizes) + b.expand(expanded_sizes) + c.expand(expanded_sizes)));
+
+    // with scalar
+    auto aTensorScalar = T.ones({1});
+    aTensorScalar.get()->maybeScalar(true);
+    b = T.randn({3, 2, 1});
+    c = T.randn({1, 2, 5});
+    assert(aTensorScalar.addcmul(b, c).equal(
+           aTensorScalar.expand(expanded_sizes).addcmul(b.expand(expanded_sizes), c.expand(expanded_sizes))));
+
+    // old fallback behavior yields error
+    try {
+      auto a = T.randn({3, 2, 5});
+      auto b = T.randn({2, 3, 5});
+      auto c = T.randn({5, 3, 2});
+      a.addcmul(b, c);
+      assert(false);
+    } catch(std::runtime_error &e) {}
+
+    // with mistmatched sizes
+    try {
+      auto c = T.randn({5, 5, 5});
+      a.addcmul(b, c);
+      assert(false);
+    } catch(std::runtime_error &e) {}
+  }
+
+  // 3) in-place function with 2 args
+  {
+    // basic
+    auto a = T.randn({3, 5});
+    auto b = T.randn({3, 1});
+    assert((a + b).equal(a + b.expand({3, 5})));
+
+    // with scalar
+    auto bScalar = T.ones({1});
+    bScalar.get()->maybeScalar(true);
+    assert((a + bScalar).equal(a + bScalar.expand(a.sizes())));
+
+    // shouldn't be able to "expand" to a scalar_type
+    try {
+      auto a = T.ones({1});
+      bScalar.add_(a);
+      assert(false);
+    } catch(std::runtime_error &e) {}
+    
+    // error: would have to expand inplace arg
+    try {
+      auto a = T.randn({1, 5});
+      auto b = T.randn({3, 1});
+      a.add_(b);
+      assert(false);
+    } catch(std::runtime_error &e) {}
+  }
+
+  // 4) in-place function with 3 args
+  {
+    // basic
+    auto a = T.randn({3, 5, 2});
+    auto aClone = a.clone();
+    auto b = T.randn({3, 1, 2});
+    auto c = T.randn({1, 5, 1});
+
+    assert(a.addcmul_(b, c).equal(aClone.addcmul_(b.expand(a.sizes()), c.expand(a.sizes()))));
+
+    // with scalar
+    auto bScalar = T.ones({1});
+    bScalar.get()->maybeScalar(true);
+    assert(a.addcmul_(bScalar, c).equal(aClone.addcmul_(bScalar.expand(a.sizes()), c.expand(a.sizes()))));
+
+    // shouldn't be able to "expand" to a scalar_type
+    try {
+      auto a = T.ones({1});
+      bScalar.addcmul_(a, a);
+      assert(false);
+    } catch(std::runtime_error &e) {}
+
+    // error: would have to expand inplace arg
+    try {
+      auto a = T.randn({1, 3, 5});
+      auto b = T.randn({4, 1, 1});
+      auto c = T.randn({1, 3, 1});
+      a.addcmul_(b, c);
+      assert(false);
+    } catch(std::runtime_error &e) {}
+  }
+  
+  // explicit dim specification
+  {
+    // basic
+    auto a = T.randn({1});
+    auto b = T.randn({5, 3});
+    auto c = T.randn({3, 7});
+    assert(a.addmm(b, c).equal(a.expand({5,7}).addmm(b, c)));
+
+    // with scalar
+    Tensor aScalar = T.ones({1});
+    aScalar.get()->maybeScalar(true);
+    assert(aScalar.addmm(b, c).equal(aScalar.expand({5, 7}).addmm(b, c)));
+
+    // with mistmatched sizes
+    try {
+      auto a = T.randn({3, 3});
+      a.addmm(b, c);
+      assert(false);
+    } catch(std::runtime_error &e) {}
+  }
+
+  return 0;
+}

--- a/src/ATen/test/broadcast_test.cpp
+++ b/src/ATen/test/broadcast_test.cpp
@@ -90,13 +90,6 @@ int main() {
     bScalar.get()->maybeScalar(true);
     assert((a + bScalar).equal(a + bScalar.expand(a.sizes())));
 
-    // shouldn't be able to "expand" to a scalar_type
-    try {
-      auto a = T.ones({1});
-      bScalar.add_(a);
-      assert(false);
-    } catch(std::runtime_error &e) {}
-
     // error: would have to expand inplace arg
     try {
       auto a = T.randn({1, 5});
@@ -120,13 +113,6 @@ int main() {
     auto bScalar = T.ones({1});
     bScalar.get()->maybeScalar(true);
     assert(a.addcmul_(bScalar, c).equal(aClone.addcmul_(bScalar.expand(a.sizes()), c.expand(a.sizes()))));
-
-    // shouldn't be able to "expand" to a scalar_type
-    try {
-      auto a = T.ones({1});
-      bScalar.addcmul_(a, a);
-      assert(false);
-    } catch(std::runtime_error &e) {}
 
     // error: would have to expand inplace arg
     try {

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -5,4 +5,5 @@ BUILD_ROOT=$1
 $BUILD_ROOT/src/ATen/test/basic
 $BUILD_ROOT/src/ATen/test/atest
 $BUILD_ROOT/src/ATen/test/scalar_test
+$BUILD_ROOT/src/ATen/test/broadcast_test
 valgrind --suppressions=`dirname $0`/valgrind.sup --error-exitcode=1 $BUILD_ROOT/src/ATen/test/basic -n


### PR DESCRIPTION
This respects all the broadcast cwrap specifications except for 'fallback';
i.e. pointwise functions operating on tensors where the number of elements
match but the sizes are different and not broadcastable.  This behavior is
currently deprecated in PyTorch.  Note that this is a breaking change in ATen,
because ATen just passes through to TH/THC, where the fallback behavior is
actually implemented.

This also changes expand semantics wrt Scalars (as tensors).  Previously,
one could 'expand' a 1-dimensional tensor with size 1 to a 'scalar' (i.e.
empty size initializer list).