### PR TITLE
Make Scalar default constructible

### DIFF
--- a/src/ATen/Scalar.h
+++ b/src/ATen/Scalar.h
@@ -12,6 +12,8 @@ namespace at {
 
 class Scalar {
 public:
+  Scalar() : Scalar(0L) {}
+
   explicit Scalar(const Tensor & t)
   : tag(Tag::HAS_t), t(t) {
     AT_ASSERT(t.dim() == 0,"Attempting to create a Scalar from a %d dim tensor",t.dim());


### PR DESCRIPTION
Adds a default constructor to Scalar which initializes to zero.

The default constructor is particularly useful when Scalar is a field in another struct, since then the containing struct can have an implicit default constructor.