### PR TITLE
Add accessor to underlying Tensor

### DIFF
--- a/src/ATen/Scalar.h
+++ b/src/ATen/Scalar.h
@@ -66,6 +66,13 @@ public:
     } \
   }
 
+  Tensor toTensor() const {
+    if (Tag::HAS_t != tag) {
+      throw std::domain_error("Scalar is not backed by a Tensor");
+    }
+    return t;
+  }
+
   AT_FORALL_SCALAR_TYPES(DEFINE_ACCESSOR)
 
   //also support scalar.to<int64_t>();

--- a/src/ATen/Scalar.h
+++ b/src/ATen/Scalar.h
@@ -3,6 +3,7 @@
 #include<stdint.h>
 #include <stdexcept>
 #include <string>
+#include "ATen/Context.h"
 #include "ATen/Half.h"
 #include "ATen/Type.h"
 #include "ATen/Utils.h"
@@ -67,10 +68,14 @@ public:
   }
 
   Tensor toTensor() const {
-    if (Tag::HAS_t != tag) {
-      throw std::domain_error("Scalar is not backed by a Tensor");
+    if (Tag::HAS_t == tag) {
+      return t;
+    } else if (Tag::HAS_d == tag) {
+      return CPU(kDouble).scalarTensor(*this);
+    } else {
+      assert(Tag::HAS_i == tag);
+      return CPU(kLong).scalarTensor(*this);
     }
-    return t;
   }
 
   AT_FORALL_SCALAR_TYPES(DEFINE_ACCESSOR)

--- a/src/ATen/test/scalar_test.cpp
+++ b/src/ATen/test/scalar_test.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include "ATen/ATen.h"
 #include "ATen/Dispatch.h"
+#include "test_assert.h"
 
 using std::cout;
 using namespace at;
@@ -68,6 +69,11 @@ int main() {
     cout << r << "\n";
   }
   cout << T.randn({10,10,2}) << "\n";
+
+  // check Scalar.toTensor on Scalars backed by different data types
+  ASSERT(bar.toTensor().type().scalarType() == kDouble);
+  ASSERT(what.toTensor().type().scalarType() == kLong);
+  ASSERT(Scalar(CPU(kFloat).ones({})).toTensor().type().scalarType() == kFloat);
 
   dispatch<Foo>(x.type(),x,prev_h);
   return 0;


### PR DESCRIPTION
Currently, you can't directly access the underlying `Tensor` in a Scalar backed by a tensor. Type has a `scalarTensor` function, but that needs to be called on a specific, concrete type instance.