### PR TITLE
Make 's_' functions on Type public

### DIFF
--- a/src/ATen/function_wrapper.py
+++ b/src/ATen/function_wrapper.py
@@ -404,7 +404,7 @@ def create_generic(top_env, declarations):
             same_size_option = option.copy()
             same_size_option['method_prefix'] = option['method_prefix_derived']
             same_size_env = nested_dict(same_size_option, top_env)
-            top_env['type_method_declarations_protected'].append(
+            top_env['type_method_declarations'].append(
                 TYPE_METHOD_DECLARATION.substitute(same_size_env))
             top_env['type_method_definitions'].append(
                 TYPE_METHOD_DEFINITION.substitute(same_size_env))

--- a/src/ATen/gen.py
+++ b/src/ATen/gen.py
@@ -85,7 +85,6 @@ top_env = {
     'type_method_declarations': [],
     'type_method_definitions': [],
     'type_method_inline_definitions': [],
-    'type_method_declarations_protected': [],
     'tensor_method_declarations': [],
     'tensor_method_definitions': [],
     'function_declarations': [],

--- a/src/ATen/templates/Type.h
+++ b/src/ATen/templates/Type.h
@@ -134,7 +134,6 @@ struct Type {
   ${type_method_declarations}
 protected:
   Context* context;
-  ${type_method_declarations_protected}
 };
 
 


### PR DESCRIPTION
Makes the `s_` ("same size") functions on `Type` public. The `Variable` subclass of `Type` needs to be able to call the `s_` functions on on the base type (e.g. `CPUFloatType`). The C++ rules for "protected" only allow an instance to call protected functions on instances of the same type -- not on other subclasses.