### PR TITLE
Fix default constructor argument

### DIFF
--- a/src/ATen/Scalar.h
+++ b/src/ATen/Scalar.h
@@ -13,7 +13,7 @@ namespace at {
 
 class Scalar {
 public:
-  Scalar() : Scalar(0L) {}
+  Scalar() : Scalar(0LL) {}
 
   explicit Scalar(const Tensor & t)
   : tag(Tag::HAS_t), t(t) {

--- a/src/ATen/Scalar.h
+++ b/src/ATen/Scalar.h
@@ -13,7 +13,7 @@ namespace at {
 
 class Scalar {
 public:
-  Scalar() : Scalar(0LL) {}
+  Scalar() : Scalar(int64_t(0)) {}
 
   explicit Scalar(const Tensor & t)
   : tag(Tag::HAS_t), t(t) {


### PR DESCRIPTION
Building ATen on my system (macOS 10.12.6, clang 8.1.0) fails on Scalar since 17757d5, with the following error:
```
/pytorch/torch/lib/ATen/../ATen/Scalar.h:16:14: error: call to constructor of
      'at::Scalar' is ambiguous
  Scalar() : Scalar(0L) {}
             ^      ~~
```
It's due to the `L` literal not leading to a suitable constructor, as generated by `AT_FORALL_SCALAR_TYPES`.

This change fixes the error (I assumed the intention was to default construct a Long scalar, but I guess anything would do).