### PR TITLE
Micro optimizations in ATen

### DIFF
--- a/src/ATen/Utils.h
+++ b/src/ATen/Utils.h
@@ -2,6 +2,7 @@
 
 #include "ArrayRef.h"
 #include <sstream>
+#include <typeinfo>
 
 namespace at {
 
@@ -19,10 +20,10 @@ static inline T* checked_cast(Base* expr, const char * name, int pos, bool allow
     runtime_error("Expected a Tensor of type %s but found an undefined Tensor for argument #%d '%s'",
       T::typeString(),pos,name);
   }
-  if(auto result = dynamic_cast<T*>(expr))
-    return result;
-  runtime_error("Expected object of type %s but found type %s for argument #%d '%s'",
-    T::typeString(),expr->type().toString(),pos,name);
+  if (typeid(*expr) != typeid(T))
+    runtime_error("Expected object of type %s but found type %s for argument #%d '%s'",
+      T::typeString(),expr->type().toString(),pos,name);
+  return static_cast<T*>(expr);
 }
 
 // Converts a TensorList (i.e. ArrayRef<Tensor> to the underlying TH* Tensor Pointer)

--- a/src/ATen/function_wrapper.py
+++ b/src/ATen/function_wrapper.py
@@ -624,13 +624,13 @@ def create_derived(backend_type_env, declarations):
                 if arg.get('cpu_zero', False) and not is_cuda:
                     body.append("{}.zero_();".format(arg['name']))
 
-                # dim() == 0 of all input tensors is and'd to form
+                # isScalar() for all input tensors is and'd to form
                 # the test for whether the output is also a scalar
                 if (not arg.get('output') and 'Tensor' in arg['type'] and
                         'TensorList' not in arg['type'] and
                         'THS' not in arg['type'] and
                         not scalar_check_is_from_size):
-                    check = '{}.dim() == 0'.format(arg['name'])
+                    check = '{}->isScalar()'.format(arg['name'] + '_')
                     scalar_check = (check if scalar_check is None
                                     else scalar_check + ' && ' + check)
 

--- a/src/ATen/gen.py
+++ b/src/ATen/gen.py
@@ -196,8 +196,10 @@ def generate_storage_type_and_tensor(backend, density, scalar_type, declarations
         write(env['Storage'] + ".cpp", STORAGE_DERIVED_CPP.substitute(env))
         write(env['Storage'] + ".h", STORAGE_DERIVED_H.substitute(env))
         env['TensorDenseOrSparse'] = TENSOR_DENSE_CPP.substitute(env)
+        env['THTensor_nDimension'] = 'tensor->nDimension'
     else:
         env['TensorDenseOrSparse'] = TENSOR_SPARSE_CPP.substitute(env)
+        env['THTensor_nDimension'] = 'tensor->nDimensionI + tensor->nDimensionV'
 
     write(env['Type'] + ".cpp", TYPE_DERIVED_CPP.substitute(env))
     write(env['Type'] + ".h", TYPE_DERIVED_H.substitute(env))

--- a/src/ATen/templates/TensorDerived.cpp
+++ b/src/ATen/templates/TensorDerived.cpp
@@ -26,7 +26,7 @@ IntList ${Tensor}::sizes() {
 int64_t ${Tensor}::dim() {
   if(isScalar())
     return 0;
-  int64_t d = ${THTensor}_nDimension(${state,}tensor);
+  int64_t d = ${THTensor_nDimension};
   // See Note [Undefined-dim versus 0-dim]
   if (d != 0)
     return d;

--- a/src/ATen/templates/TensorDerived.h
+++ b/src/ATen/templates/TensorDerived.h
@@ -9,7 +9,7 @@ $th_headers
 
 namespace at {
 
-struct ${Tensor} : public TensorImpl {
+struct ${Tensor} final : public TensorImpl {
 public:
   explicit ${Tensor}(Context* context);
   ${Tensor}(Context* context, ${THTensor} * tensor);

--- a/src/ATen/templates/TypeDerived.h
+++ b/src/ATen/templates/TypeDerived.h
@@ -6,7 +6,7 @@
 
 namespace at {
 
-struct ${Type} : public Type {
+struct ${Type} final : public Type {
   explicit ${Type}(Context* context);
   virtual ScalarType scalarType() override;
   virtual Backend backend() override;


### PR DESCRIPTION
* Compare typeid instead of using dynamic_cast
* Mark derived TensorImpl classes as final
* Use tensor->nDimension instead of THTensor_(nDimension)

For a 1x1 tensor:
- Shaves off ~30 ns (out of 190 ns) for `addmm_`
- Shaves off ~60 ns (out of 625 ns) for `addmm`