### PR TITLE
Support wrap_dim in Local.cwrap and _unnarrow (backwards of narrow)

### DIFF
--- a/src/ATen/Local.cwrap
+++ b/src/ATen/Local.cwrap
@@ -65,6 +65,29 @@
 ]]
 
 [[
+  name: _unnarrow
+  variants: [method,function]
+  return: argument 0
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - THTensor* self
+    - arg: int64_t dimension
+      wrap_dim: self
+    - int64_t offset
+    - int64_t dimSize
+  aten_custom_call: |
+    int64_t ndim = self.dim();
+    AT_ASSERT(ndim > 0, "unnarrow() cannot be applied to a 0-dim tensor.");
+    std::vector<int64_t> self_sizes = self.sizes();
+    self_sizes[dimension] = dimSize;
+    auto self_sizes_ = THLongStorageView::make(self_sizes, true);
+    ${THTensor}_zeros(${state,}result_->tensor, self_sizes_);
+    auto narrowed_result = result.narrow(dimension, offset, self.size(dimension));
+    narrowed_result.copy_(self);
+]]
+
+[[
   name: assign_
   cname: copy
   cpu_half: True

--- a/src/ATen/Local.cwrap
+++ b/src/ATen/Local.cwrap
@@ -4,7 +4,8 @@
   cpu_half: True
   arguments:
     - THTensor* self
-    - int64_t dim
+    - arg: int64_t dim
+      wrap_dim: self
 ]]
 
 [[
@@ -13,7 +14,8 @@
   cpu_half: True
   arguments:
     - THTensor* self
-    - int64_t dim
+    - arg: int64_t dim
+      wrap_dim: self
 ]]
 
 
@@ -48,7 +50,8 @@
     - arg: THTensor* result
       output: True
     - THTensor* self
-    - int64_t dim
+    - arg: int64_t dim
+      wrap_dim: self
     - int64_t sliceIndex
   aten_custom_call: |
     int64_t ndim = self.dim();
@@ -80,5 +83,6 @@
     - arg: THTensor* self
       output: True
     - TensorList tensors
-    - int64_t dim
+    - arg: int64_t dim
+      wrap_dim: tensors
 ]]

--- a/src/ATen/Utils.h
+++ b/src/ATen/Utils.h
@@ -51,21 +51,4 @@ static inline std::vector<TH*> tensor_list_checked_cast(ArrayRef<TBase> tensors,
   return casted;
 }
 
-static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr) {
-  int64_t corrected_dim = std::max<int64_t>(dim_post_expr, 0);
-  if (corrected_dim <= 0) {
-    std::ostringstream oss;
-    oss << "dimension specified as " << dim << " but tensor has no dimensions";
-    throw std::runtime_error(oss.str());
-  }
-  if (dim < -(corrected_dim) || dim >= (corrected_dim)) {
-    std::ostringstream oss;
-    oss << "dimension out of range (expected to be in range of [" << -(corrected_dim)
-        << ", " << (corrected_dim)-1 << "], but got " << dim << ")",
-    throw std::runtime_error(oss.str());
-  }
-  if (dim  < 0) dim += corrected_dim;
-  return dim;
-}
-
 } // at

--- a/src/ATen/WrapDimUtils.h
+++ b/src/ATen/WrapDimUtils.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "ATen/TensorImpl.h"
+#include <sstream>
+
+namespace at {
+
+static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr) {
+  if (dim_post_expr <= 0) {
+    std::ostringstream oss;
+    oss << "dimension specified as " << dim << " but tensor has no dimensions";
+    throw std::runtime_error(oss.str());
+  }
+  if (dim < -(dim_post_expr) || dim >= (dim_post_expr)) {
+    std::ostringstream oss;
+    oss << "dimension out of range (expected to be in range of [" << -(dim_post_expr)
+        << ", " << (dim_post_expr)-1 << "], but got " << dim << ")",
+    throw std::runtime_error(oss.str());
+  }
+  if (dim  < 0) dim += dim_post_expr;
+  return dim;
+}
+
+static inline int64_t maybe_wrap_dim(int64_t dim, TensorImpl *tensor, int64_t to_add) {
+  return maybe_wrap_dim(dim, tensor->dim() + to_add);
+}
+
+static inline int64_t maybe_wrap_dim(int64_t dim, TensorList tensors, int64_t to_add) {
+  if (tensors.size() == 0) {
+    // can't wrap empty TensorList; rely on underlying implementation to throw error if necessary.
+    return dim;
+  }
+  return maybe_wrap_dim(dim, tensors[0].dim() + to_add);
+}
+
+}

--- a/src/ATen/templates/TypeDerived.cpp
+++ b/src/ATen/templates/TypeDerived.cpp
@@ -7,6 +7,7 @@
 #include "ATen/${Backend}LongTensor.h"
 #include "ATen/${SparseTensor}.h"
 #include "ATen/Utils.h"
+#include "ATen/WrapDimUtils.h"
 #include "ATen/THLongStorageView.h"
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
These are the changes necessary to support existing "torch.cat" and "narrow" functionality in autograd.

This involves 3 main changes:
1) Enable wrap_dim on tensor arguments for existing functions in Local.cwrap
2) Support wrap_dim on TensorList arguments (for torch.cat) and specify for torch.cat (this involved moving some code around to make it easier to support both Tensor and TensorList specifications.
3) Implement _unnarrow (backward of narrow) in Local.cwrap.  This is currently prefixed with an underscore because it may go away (backwards of narrow could be implemented with index, but that's not all implemented and hooked up yet).