### PR TITLE
Specify split and chunk as ATen native functions.

### DIFF
--- a/src/ATen/WrapDim.h
+++ b/src/ATen/WrapDim.h
@@ -21,16 +21,4 @@ static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr) {
   return dim;
 }
 
-static inline int64_t maybe_wrap_dim(int64_t dim, TensorImpl *tensor, int64_t to_add) {
-  return maybe_wrap_dim(dim, tensor->dim() + to_add);
-}
-
-static inline int64_t maybe_wrap_dim(int64_t dim, TensorList tensors, int64_t to_add) {
-  if (tensors.size() == 0) {
-    // can't wrap empty TensorList; rely on underlying implementation to throw error if necessary.
-    return dim;
-  }
-  return maybe_wrap_dim(dim, tensors[0].dim() + to_add);
-}
-
 }

--- a/src/ATen/WrapDimTensors.h
+++ b/src/ATen/WrapDimTensors.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "ATen/TensorImpl.h"
+#include "ATen/WrapDim.h"
+#include <sstream>
+
+namespace at {
+
+static inline int64_t maybe_wrap_dim(int64_t dim, TensorImpl *tensor, int64_t to_add) {
+  return maybe_wrap_dim(dim, tensor->dim() + to_add);
+}
+
+static inline int64_t maybe_wrap_dim(int64_t dim, TensorList tensors, int64_t to_add) {
+  if (tensors.size() == 0) {
+    // can't wrap empty TensorList; rely on underlying implementation to throw error if necessary.
+    return dim;
+  }
+  return maybe_wrap_dim(dim, tensors[0].dim() + to_add);
+}
+
+}

--- a/src/ATen/gen.py
+++ b/src/ATen/gen.py
@@ -2,6 +2,7 @@ from optparse import OptionParser
 import yaml
 
 import cwrap_parser
+import raw_outputdecl_parser
 import nn_parse
 import preprocess_declarations
 import function_wrapper
@@ -232,7 +233,14 @@ for fname, env in generators.items():
 # and modify the declarations to include any information that will all_backends
 # be used by function_wrapper.create_derived
 output_declarations = function_wrapper.create_generic(top_env, declarations)
-write("Declarations.yaml", format_yaml(output_declarations))
+
+# directly read any output_declarations specified in appropriate headers
+raw_output_declaration_search_path = [TEMPLATE_PATH + "/Tensor.h"]
+raw_output_decls = []
+for file in raw_output_declaration_search_path:
+    raw_output_decls += raw_outputdecl_parser.parse(file)
+
+write("Declarations.yaml", format_yaml(output_declarations) + '\n'.join(raw_output_decls))
 
 # populated by generate_storage_type_and_tensor
 all_types = []

--- a/src/ATen/raw_outputdecl_parser.py
+++ b/src/ATen/raw_outputdecl_parser.py
@@ -1,0 +1,22 @@
+# finds raw declarations between [Declarations.yaml] and [/Declarations.yaml]
+
+def parse(filename):
+    with open(filename, 'r') as file:
+        declaration_lines = []
+        declarations = []
+        in_declaration = False
+        lstrip_chars = 0
+        for line in file.readlines():
+            line = line.rstrip()
+            if '[Declarations.yaml]' in line:
+                declaration_lines = []
+                in_declaration = True
+                lstrip_chars = len(line) - len(line.lstrip())
+            elif '[/Declarations.yaml]' in line:
+                in_declaration = False
+                declarations.append('\n'.join(declaration_lines))
+            elif in_declaration:
+                if line[:lstrip_chars] == ' ' * lstrip_chars:
+                    line = line[lstrip_chars:]
+                declaration_lines.append(line)
+        return declarations

--- a/src/ATen/raw_outputdecl_parser.py
+++ b/src/ATen/raw_outputdecl_parser.py
@@ -1,5 +1,6 @@
 # finds raw declarations between [Declarations.yaml] and [/Declarations.yaml]
 
+
 def parse(filename):
     with open(filename, 'r') as file:
         declaration_lines = []

--- a/src/ATen/templates/TypeDerived.cpp
+++ b/src/ATen/templates/TypeDerived.cpp
@@ -7,7 +7,7 @@
 #include "ATen/${Backend}LongTensor.h"
 #include "ATen/${SparseTensor}.h"
 #include "ATen/Utils.h"
-#include "ATen/WrapDimUtils.h"
+#include "ATen/WrapDimTensors.h"
 #include "ATen/THLongStorageView.h"
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
Declarations.yaml entries are specified directly in the comments;
WrapDimUtils had to be split into two separate files because TensorList
isn't defined when it is used in split/chunk in Tensor.h.