### PR TITLE
add a deleter callback to tensorFromBlob

### DIFF
--- a/src/ATen/templates/StorageDerived.h
+++ b/src/ATen/templates/StorageDerived.h
@@ -13,7 +13,7 @@ public:
   ${Storage}(Context* context, ${THStorage} *wrapped);
   ${Storage}(Context* context, std::size_t size);
   ${Storage}(Context* context,
-    void * data, std::size_t size);
+    void * data, std::size_t size, const std::function<void(void*)> & deleter);
   virtual ~${Storage}();
 
   virtual std::size_t elementSize() const override;

--- a/src/ATen/templates/Type.cpp
+++ b/src/ATen/templates/Type.cpp
@@ -27,16 +27,16 @@ Type & Type::toScalarType(ScalarType s) const {
   return context->getType(backend(),s);
 }
 
-Tensor Type::tensorFromBlob(void * data, IntList sizes) const {
+Tensor Type::tensorFromBlob(void * data, IntList sizes, const std::function<void(void*)> & deleter) {
   std::vector<int64_t> strides(sizes.size());
   int64_t stride = 1;
   for(size_t i = sizes.size(); i > 0; --i) {
     strides[i-1] = stride;
     stride *= sizes[i-1];
   }
-  return tensorFromBlob(data, sizes, strides);
+  return tensorFromBlob(data, sizes, strides, deleter);
 }
-Tensor Type::tensorFromBlob(void * data, IntList sizes, IntList strides) const {
+Tensor Type::tensorFromBlob(void * data, IntList sizes, IntList strides, const std::function<void(void*)> & deleter) {
   // size of the underlying storage is 1 bigger than the offset
   // of the last element according to stride
   int64_t size = 1;
@@ -47,7 +47,7 @@ Tensor Type::tensorFromBlob(void * data, IntList sizes, IntList strides) const {
     }
     size += strides[i]*(sizes[i]-1);
   }
-  auto storage = storageFromBlob(data,size);
+  auto storage = storageFromBlob(data,size,deleter);
   return tensor(*storage, 0, sizes, strides);
 }
 Tensor Type::scalarTensor(Scalar s) const {

--- a/src/ATen/templates/Type.h
+++ b/src/ATen/templates/Type.h
@@ -37,6 +37,8 @@ struct Generator;
 // situation.
 constexpr int64_t kUndefinedDimensions = std::numeric_limits<int64_t>::min();
 
+static void noop_deleter(void*) {}
+
 enum class TypeID {
   ${type_ids}
   NumOptions
@@ -55,7 +57,7 @@ struct ATen_CLASS Type {
   static void registerAll(Context * context);
   virtual std::unique_ptr<Storage> storage() const = 0;
   virtual std::unique_ptr<Storage> storage(size_t size) const = 0;
-  virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size) const = 0;
+  virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter=noop_deleter) const = 0;
   virtual std::unique_ptr<Generator> generator() const = 0;
   virtual Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const = 0;
   virtual const char * toString() const = 0;
@@ -70,8 +72,8 @@ struct ATen_CLASS Type {
   virtual void copy(const Tensor & src, Tensor & dst) const = 0;
   Tensor copy(const Tensor & src) const;
 
-  Tensor tensorFromBlob(void * data, IntList sizes) const;
-  Tensor tensorFromBlob(void * data, IntList sizes, IntList strides) const;
+  Tensor tensorFromBlob(void * data, IntList sizes, const std::function<void(void*)> & deleter=noop_deleter);
+  Tensor tensorFromBlob(void * data, IntList sizes, IntList strides, const std::function<void(void*)> & deleter=noop_deleter);
   Tensor scalarTensor(Scalar s) const;
 
   bool operator==(const Type& other) const;

--- a/src/ATen/templates/TypeDerived.cpp
+++ b/src/ATen/templates/TypeDerived.cpp
@@ -32,9 +32,9 @@ std::unique_ptr<Storage> ${Type}::storage() const {
 std::unique_ptr<Storage> ${Type}::storage(size_t size) const {
   return std::unique_ptr<Storage>(new ${Storage}(context,size));
 }
-std::unique_ptr<Storage> ${Type}::storageFromBlob(void * data, int64_t size) const {
+std::unique_ptr<Storage> ${Type}::storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const {
     return std::unique_ptr<Storage>(
-      new ${Storage}(context,data,size));
+      new ${Storage}(context,data,size,deleter));
 }
 Tensor ${Type}::unsafeTensorFromTH(void * th_pointer, bool retain) const {
   if (retain)

--- a/src/ATen/templates/TypeDerived.h
+++ b/src/ATen/templates/TypeDerived.h
@@ -21,7 +21,7 @@ struct ${Type} final : public Type {
   virtual bool isDistributed() const override;
   virtual std::unique_ptr<Storage> storage() const override;
   virtual std::unique_ptr<Storage> storage(size_t size) const override;
-  virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size) const override;
+  virtual std::unique_ptr<Storage> storageFromBlob(void * data, int64_t size, const std::function<void(void*)> & deleter) const override;
   virtual std::unique_ptr<Generator> generator() const override;
   virtual const char * toString() const override;
   virtual std::size_t elementSizeInBytes() const override;

--- a/src/ATen/test/atest.cpp
+++ b/src/ATen/test/atest.cpp
@@ -76,5 +76,40 @@ int main() {
     threw = true;
   }
   check(threw);
+  {
+    bool isgone = 0;
+    {
+      auto f2 = CPU(kFloat).tensorFromBlob(data, {1,2,3}, [&](void*) {
+        isgone++;
+      });
+      cout << f2 << endl;
+    }
+    check(isgone == 1);
+  }
+  {
+    bool isgone = 0;
+    Tensor a_view;
+    {
+      auto f2 = CPU(kFloat).tensorFromBlob(data, {1,2,3}, [&](void*) {
+        isgone++;
+      });
+      a_view = f2.view({3,2,1});
+    }
+    check(isgone == 0);
+    a_view.reset();
+    check(isgone == 1);
+  }
+
+  if(at::hasCUDA()) {
+    bool isgone = 0;
+    {
+      auto f2 = CUDA(kFloat).tensorFromBlob(nullptr, {1,2,3}, [&](void*) {
+        isgone++;
+      });
+    }
+    check(isgone==1);
+  }
+
+
   return 0;
 }


### PR DESCRIPTION
This provides a way to get a callback when ATen no longer needs the data that was captured when using tensorFromBlob. This will be useful when creating views of Caffe2 tensors from within PyTorch.