### PR TITLE
Relax Scalar::toXXX conversions to only check for overflow

### DIFF
--- a/src/ATen/Scalar.cpp
+++ b/src/ATen/Scalar.cpp
@@ -36,6 +36,13 @@ template<> int64_t convert(Half f) {
   return static_cast<int64_t>(convert<double,Half>(f));
 }
 
+template<> bool overflows<Half, double>(double f) {
+  return f > 65504 || f < -65504;
+}
+template<> bool overflows<Half, int64_t>(int64_t f) {
+  return f > 65504 || f < -65504;
+}
+
 
 #ifdef AT_CUDA_ENABLED
 template<> half convert(double d) {

--- a/src/ATen/Scalar.h
+++ b/src/ATen/Scalar.h
@@ -62,18 +62,9 @@ public:
     if (Tag::HAS_t == tag) { \
       return local().to##name(); \
     } else if (Tag::HAS_d == tag) { \
-      auto casted = convert<type,double>(v.d); \
-      if(convert<double,type>(casted) != v.d) { \
-        throw std::domain_error(std::string("value cannot be losslessly represented in type " #name ": ") + std::to_string(v.d) ); \
-      } \
-      return casted; \
+      return checked_convert<type, double>(v.d, #type); \
     } else { \
-      assert(Tag::HAS_i == tag); \
-      auto casted = convert<type,int64_t>(v.i); \
-      if(convert<int64_t,type>(casted) != v.i) { \
-        throw std::domain_error(std::string("value cannot be losslessly represented in type " #name ": ") + std::to_string(v.i)); \
-      } \
-      return casted; \
+      return checked_convert<type, int64_t>(v.i, #type); \
     } \
   }
 


### PR DESCRIPTION
Currently, the toXXX functions on Scalar check that the conversions are
exact. This will cause an exception in code like:

```
  auto t = CPU(kFloat).ones({1});
  t *= M_PI;
```

Or the equivalent in Python:

```
  t = torch.ones(1)
  t *= math.pi
```

This changes the checks to only throw an exception in the case of
overflow (positive or negative).