### PR TITLE
Support 'native' ATen functions with Tensor, (base) Type, NS impls.

### DIFF
--- a/src/ATen/NativeFunctions.h
+++ b/src/ATen/NativeFunctions.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <ATen/ATen.h>
+#include <vector>
+
+namespace at {
+namespace native {
+
+/*
+[NativeFunction]
+name: split
+arg: Tensor self
+arg: int64_t split_size
+arg: int64_t dim
+return: TensorList
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::split
+[/NativeFunction]
+*/
+static inline std::vector<Tensor> split(const Tensor &self, int64_t split_size, int64_t dim) {
+  int64_t dim_size = self.size(dim);
+  int64_t num_splits = (dim_size + split_size - 1) / split_size;
+  std::vector<Tensor> splits(num_splits);
+  int64_t last_split_size = split_size - (split_size * num_splits - dim_size);
+
+  for (int64_t i = 0; i < num_splits; ++i) {
+    auto length = i < num_splits - 1 ? split_size : last_split_size;
+    splits[i] = self.narrow(dim, i * split_size, length);
+  }
+  return splits;
+}
+
+/*
+[NativeFunction]
+name: chunk
+arg: Tensor self
+arg: int64_t chunks
+arg: int64_t dim
+return: TensorList
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::chunk
+[/NativeFunction]
+*/
+static inline std::vector<Tensor> chunk(const Tensor &self, int64_t chunks, int64_t dim) {
+  int64_t split_size = (self.size(dim) + chunks - 1) / chunks;
+  return at::native::split(self, split_size, dim);
+}
+
+}
+}

--- a/src/ATen/gen.py
+++ b/src/ATen/gen.py
@@ -3,6 +3,7 @@ import yaml
 
 import cwrap_parser
 import nn_parse
+import native_parse
 import preprocess_declarations
 import function_wrapper
 import dispatch_macros
@@ -46,6 +47,8 @@ TENSOR_H = CodeTemplate.from_file(TEMPLATE_PATH + "/Tensor.h")
 TENSOR_METHODS_H = CodeTemplate.from_file(TEMPLATE_PATH + "/TensorMethods.h")
 
 FUNCTIONS_H = CodeTemplate.from_file(TEMPLATE_PATH + "/Functions.h")
+
+NATIVE_FUNCTIONS_PATH = options.source_path + "/NativeFunctions.h"
 
 generators = {
     'CPUGenerator.h': {
@@ -223,6 +226,7 @@ declarations = [d
                 for file in cwrap_files
                 for d in cwrap_parser.parse(file)]
 declarations += nn_parse.run(nn_files)
+declarations += native_parse.parse(NATIVE_FUNCTIONS_PATH)
 declarations = preprocess_declarations.run(declarations)
 for fname, env in generators.items():
     write(fname, GENERATOR_DERIVED.substitute(env))

--- a/src/ATen/native_parse.py
+++ b/src/ATen/native_parse.py
@@ -6,7 +6,7 @@ def parse(filename):
             if '[NativeFunction]' in line:
                 in_declaration = True
                 arguments = []
-                declaration = {}
+                declaration = {'mode': 'native'}
             elif '[/NativeFunction]' in line:
                 in_declaration = False
                 declaration['arguments'] = arguments

--- a/src/ATen/native_parse.py
+++ b/src/ATen/native_parse.py
@@ -1,0 +1,25 @@
+def parse(filename):
+    with open(filename, 'r') as file:
+        declarations = []
+        in_declaration = False
+        for line in file.readlines():
+            if '[NativeFunction]' in line:
+                in_declaration = True
+                arguments = []
+                declaration = {}
+            elif '[/NativeFunction]' in line:
+                in_declaration = False
+                declaration['arguments'] = arguments
+                declarations.append(declaration)
+                if declaration.get('type_method_definition_level') != 'base':
+                    raise RuntimeError("Native functions currently only support (and must be specified with) "
+                                       "\'base\' type_method_definition_level")
+            elif in_declaration:
+                ls = line.strip().split(':', 1)
+                key = ls[0].strip()
+                value = ls[1].strip()
+                if key == 'arg':
+                    arguments.append({key: value})
+                else:
+                    declaration[key] = value
+        return declarations

--- a/src/ATen/templates/Type.cpp
+++ b/src/ATen/templates/Type.cpp
@@ -4,6 +4,7 @@
 #include "ATen/Scalar.h"
 #include "ATen/SparseTensorRef.h"
 #include "ATen/ExpandUtils.h"
+#include "ATen/NativeFunctions.h"
 
 #include <iostream>
 ${type_headers}

--- a/src/ATen/test/CMakeLists.txt
+++ b/src/ATen/test/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(wrapdim_test ATen)
 
 add_executable(dlconvertor_test dlconvertor_test.cpp)
 target_link_libraries(dlconvertor_test ATen)
+
+add_executable(native_test native_test.cpp)
+target_link_libraries(native_test ATen)

--- a/src/ATen/test/native_test.cpp
+++ b/src/ATen/test/native_test.cpp
@@ -1,0 +1,42 @@
+#include "ATen/ATen.h"
+
+using namespace at;
+
+void assertEqualTensorList(TensorList t1, TensorList t2) {
+  assert(t1.size() == t2.size());
+  for (size_t i = 0; i < t1.size(); ++i) {
+    assert(t1[ i ].equal(t2[ i ]));
+  }
+}
+
+int main() {
+  Type & T = CPU(kFloat);
+
+  auto t = T.randn({3, 3});
+  // split
+  {
+    // test method, type, namespace give same result
+    auto splitMethod = t.split(1, 0);
+    auto splitType = T.split(t, 1, 0);
+    auto splitNs = at::split(t, 1, 0);
+    assertEqualTensorList(splitMethod, splitType);
+    assertEqualTensorList(splitMethod, splitNs);
+
+    // test rebuilding with cat
+    assert(at::cat(splitMethod, 0).equal(t));
+  }
+
+  {
+    // test method, type, namespace give same result
+    auto chunkMethod = t.chunk(3, 0);
+    auto chunkType = T.chunk(t, 3, 0);
+    auto chunkNs = at::chunk(t, 3, 0);
+    assertEqualTensorList(chunkMethod, chunkType);
+    assertEqualTensorList(chunkMethod, chunkNs);
+
+    // test rebuilding with cat
+    assert(at::cat(chunkMethod, 0).equal(t));
+  }
+
+  return 0;
+}

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -8,4 +8,5 @@ $BUILD_ROOT/src/ATen/test/scalar_test
 $BUILD_ROOT/src/ATen/test/broadcast_test
 $BUILD_ROOT/src/ATen/test/wrapdim_test
 $BUILD_ROOT/src/ATen/test/dlconvertor_test
+$BUILD_ROOT/src/ATen/test/native_test
 valgrind --suppressions=`dirname $0`/valgrind.sup --error-exitcode=1 $BUILD_ROOT/src/ATen/test/basic -n


### PR DESCRIPTION
This adds the ability to specify 'native' functions in NativeFunctions.h and specifies
'split' and 'chunk' in this manner.  The function arguments, returns, variants, etc. are
specified as if they were processed via other parsing mechanisms (e.g. cwrap_parse) with
the following additional parameters:

type_method_definition_level: this allows one to specify that the type method should
be defined at the 'base' type level; this is because in the case of 'split' and 'chunk'
(and probably most/all other native functions that don't directly dispatch to TH/THC)
we don't need type-specific implementations.  Currently it is enforced that 'base' is
specified for native functions, but this is easy to remove later.

type_method_definition_dispatch: this defines the function to dispatch to.  For split,
this is at::native::split; this is just to avoid having a magic namespace and allowing
one to dispatch to a function with a different name.