### PR TITLE
Conda packaging

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -6,12 +6,16 @@ if [ -z "$PREFIX" ]; then
   PREFIX="$CONDA_PREFIX"
 fi
 
-# conda build will copy everything over, including build directories.
-# Don't let this pollute the build!
+# When conda-build constructs a new working copy to perform a build
+# in, it recursively copies *all* files and directories in the original
+# source directory, including any pre-existing build products (e.g.,
+# if you previously ran cmake.)  This is problematic, because if
+# a 'build' directory already exists, cmake will reuse build settings
+# rather than recompute them from scratch.  We want a fresh build, so
+# we prophylactically remove the build directory.
 rm -rf build || true
 
 mkdir -p build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_PREFIX_PATH="$PREFIX" -DCMAKE_BUILD_TYPE=Release $CONDA_CMAKE_ARGS ..
-# Work around https://github.com/zdevito/ATen/issues/92
-make install -j20 || make install -j20
+make install -j20

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$PREFIX" ]; then
+  PREFIX="$CONDA_PREFIX"
+fi
+
+# conda build will copy everything over, including build directories.
+# Don't let this pollute the build!
+rm -rf build || true
+
+mkdir -p build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX="$PREFIX" -DCMAKE_PREFIX_PATH="$PREFIX" -DCMAKE_BUILD_TYPE=Release $CONDA_CMAKE_ARGS ..
+# Work around https://github.com/zdevito/ATen/issues/92
+make install -j20 || make install -j20

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = "0.1.dev" %}
+
+package:
+  name: aten
+  version: {{ version }}
+
+source:
+  path: ..
+
+build:
+  number: 1
+  skip: True  # [win]
+  script_env:
+    - CONDA_CMAKE_ARGS
+
+requirements:
+  build:
+    - cmake
+    - pyyaml
+    - setuptools
+    - python
+    - mkl # [not osx]
+  run:
+    - mkl # [not osx]
+
+about:
+  home: https://github.com/zdevito/ATen
+  license: BSD
+  summary: A TENsor library for C++11
+
+extra:
+  recipe-maintainers:
+    - ezyang


### PR DESCRIPTION
There is a minor bug, I think, which is that we need a run-time dep on `libstdcxx-ng`.