### PR TITLE
remove CMAKE_CXX_STANDARD stuff in favor of setting --std=c++11 direc…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,7 @@ if("${isSystemDir}" STREQUAL "-1")
 endif()
 
 # C++11
-if(CMAKE_VERSION VERSION_LESS "3.1")
-  set(CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
-else()
-  set(CMAKE_CXX_STANDARD 11)
-endif()
-
-set(CUDA_NVCC_FLAGS "--std=c++11")
+set(CMAKE_CXX_FLAGS "--std=c++11 ${CMAKE_CXX_FLAGS}")
 
 # TH stuff
 set(Torch_FOUND 1)


### PR DESCRIPTION
…tly because parts of FindCUDA ignore the former approach

Fixes #92