### PR TITLE
The at::cat should default to dim=0

### DIFF
--- a/src/ATen/Local.cwrap
+++ b/src/ATen/Local.cwrap
@@ -111,4 +111,5 @@
     - TensorList tensors
     - arg: int64_t dim
       wrap_dim: tensors
+      default: 0
 ]]


### PR DESCRIPTION
For compatibility with PyTorch