### PR TITLE
Change is_same_size to a native function.

### DIFF
--- a/src/ATen/Declarations.cwrap
+++ b/src/ATen/Declarations.cwrap
@@ -213,16 +213,6 @@
     - real value
 ]]
 [[
-  name: isSameSizeAs
-  python_name: is_same_size
-  cpu_half: True
-  auto_gpu: False
-  return: bool
-  arguments:
-    - THTensor* self
-    - THTensor* other
-]]
-[[
   name: isContiguous
   python_name: is_contiguous
   cpu_half: True

--- a/src/ATen/NativeFunctions.h
+++ b/src/ATen/NativeFunctions.h
@@ -49,5 +49,20 @@ static inline std::vector<Tensor> chunk(const Tensor &self, int64_t chunks, int6
   return self.split(split_size, dim);
 }
 
+/*
+[NativeFunction]
+name: is_same_size
+arg: Tensor self
+arg: Tensor other
+return: bool
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::is_same_size
+[/NativeFunction]
+*/
+static inline bool is_same_size(const Tensor &self, const Tensor &other) {
+  return self.dim() == other.dim() && self.sizes().equals(other.sizes());
+}
+
 }
 }


### PR DESCRIPTION
For one thing, we will want a different implementation from TH because
we need to differentiate between scalars and 1-dim tensors.

Also, we don't really want to expose the THS/THCS function; in addition to
checking the shapes are the same, it checks that the dimensions which
are sparse are the same (because various THS/THCS operators only work if this
is true; it should really be called "is_congruent" or similar.