### PR TITLE
Make size, strides, dim functions const.

### DIFF
--- a/src/ATen/TensorImpl.h
+++ b/src/ATen/TensorImpl.h
@@ -17,9 +17,9 @@ struct TensorImpl {
     return *type_;
   }
   virtual const char * toString() const = 0;
-  virtual IntList sizes() = 0;
-  virtual IntList strides() = 0;
-  virtual int64_t dim() = 0;
+  virtual IntList sizes() const = 0;
+  virtual IntList strides() const = 0;
+  virtual int64_t dim() const = 0;
   virtual Scalar localScalar() = 0;
   virtual void assign_(Scalar s) = 0;
   virtual void * unsafeGetTH(bool retain) = 0;

--- a/src/ATen/templates/TensorDense.cpp
+++ b/src/ATen/templates/TensorDense.cpp
@@ -1,6 +1,6 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
 
-IntList ${Tensor}::strides() {
+IntList ${Tensor}::strides() const {
   return IntList(reinterpret_cast<int64_t*>(tensor->stride),dim());
 }
 Scalar ${Tensor}::localScalar() {

--- a/src/ATen/templates/TensorDerived.cpp
+++ b/src/ATen/templates/TensorDerived.cpp
@@ -19,11 +19,11 @@ const char * ${Tensor}::toString() const {
   return "${Tensor}";
 }
 
-IntList ${Tensor}::sizes() {
+IntList ${Tensor}::sizes() const {
   return IntList(reinterpret_cast<int64_t*>(tensor->size),dim());
 }
 
-int64_t ${Tensor}::dim() {
+int64_t ${Tensor}::dim() const {
   if(isScalar())
     return 0;
   int64_t d = ${THTensor_nDimension};

--- a/src/ATen/templates/TensorDerived.h
+++ b/src/ATen/templates/TensorDerived.h
@@ -15,9 +15,9 @@ public:
   ${Tensor}(Context* context, ${THTensor} * tensor);
   virtual ~${Tensor}();
   virtual const char * toString() const override;
-  virtual IntList sizes() override;
-  virtual IntList strides() override;
-  virtual int64_t dim() override;
+  virtual IntList sizes() const override;
+  virtual IntList strides() const override;
+  virtual int64_t dim() const override;
   virtual Scalar localScalar() override;
   virtual void assign_(Scalar s) override;
   virtual void * unsafeGetTH(bool retain) override;

--- a/src/ATen/templates/TensorSparse.cpp
+++ b/src/ATen/templates/TensorSparse.cpp
@@ -1,5 +1,5 @@
 // included as 'TensorDenseOrSparse' in TensorDerived.cpp
-IntList ${Tensor}::strides() {
+IntList ${Tensor}::strides() const {
   runtime_error("Sparse tensors do not have strides.");
 }
 Scalar ${Tensor}::localScalar() {


### PR DESCRIPTION
This makes these functions consistent with the other const TensorImpl functions and allows you to write a native `expand` function as a const function.