### PR TITLE
Adds permute and as_strided to ATen

### DIFF
--- a/src/ATen/Local.cwrap
+++ b/src/ATen/Local.cwrap
@@ -101,6 +101,20 @@
 ]]
 
 [[
+  name: as_strided
+  variants: [method,function]
+  return: argument 0
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - THTensor* self
+    - THSize* size
+    - THStride* stride
+  aten_custom_call: |
+    ${THTensor}_setStorage(${state,}result_->tensor, self_->tensor->storage, self_->tensor->storageOffset, size_, stride_);
+]]
+
+[[
   name: cat
   cname: catArray
   variants: [function]

--- a/src/ATen/NativeFunctions.h
+++ b/src/ATen/NativeFunctions.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ATen/ATen.h>
+#include "ATen/ATen.h"
+#include "ATen/WrapDimUtils.h"
 #include <vector>
 
 namespace at {
@@ -47,6 +48,39 @@ static inline std::vector<Tensor> chunk(const Tensor &self, int64_t chunks, int6
   int64_t split_size = (self.size(dim) + chunks - 1) / chunks;
   // ensure this is dispatched through Tensor/Type, rather than the native function directly.
   return self.split(split_size, dim);
+}
+
+/*
+[NativeFunction]
+name: permute
+arg: Tensor self
+arg: IntList dims
+return: Tensor
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::permute
+[/NativeFunction]
+*/
+static inline Tensor permute(const Tensor & self, IntList dims) {
+  auto nDims = self.dim();
+  if (dims.size() != (size_t)nDims) {
+    runtime_error("number of dims don't match in permute");
+  }
+  auto oldSizes = self.sizes();
+  auto oldStrides = self.strides();
+  std::vector<int64_t> newSizes(nDims);
+  std::vector<int64_t> newStrides(nDims);
+  std::vector<bool> seen(nDims);
+  for (int64_t i = 0; i < nDims; i++) {
+    auto dim = maybe_wrap_dim(dims[i], nDims);
+    if (seen[dim]) {
+      runtime_error("repeated dim in permute");
+    }
+    seen[dim] = true;
+    newSizes[i] = oldSizes[dim];
+    newStrides[i] = oldStrides[dim];
+  }
+  return self.as_strided(newSizes, newStrides);
 }
 
 }

--- a/src/ATen/test/basic.cpp
+++ b/src/ATen/test/basic.cpp
@@ -125,6 +125,13 @@ static void test(Type & type) {
   }
 
   {
+    Tensor a = type.rand({3, 4, 5});
+    Tensor b = a.permute({1, 2, 0});
+    ASSERT(b.sizes().equals({4, 5, 3}));
+    ASSERT(b.strides().equals({5, 1, 20}));
+  }
+
+  {
     std::cout << "mm:" << std::endl;
     Tensor a = type.rand({3, 4});
     Tensor b = type.rand({4});


### PR DESCRIPTION
```
Adds permute and as_strided to ATen

Permute transposes multiple dimensions at once. The as_strided function
changes the sizes and strides of a tensor without changing the Storage.
It's a subset of Tensor::set_.
```

Permute could be implemented as series of transpose() calls, but I think that would complicate the implementation.

There's currently no way to get a `Storage` from a `Tensor`. There isn't an easy fix for this because `Storage` is abstract base class and doesn't embed the smart-pointer like reference counting. `as_strided` works around this -- most calls don't actually need to change the `Storage`.