### PR TITLE
Make toScalarType and toBackend virtual

### DIFF
--- a/src/ATen/Formatting.cpp
+++ b/src/ATen/Formatting.cpp
@@ -244,7 +244,8 @@ std::ostream& print(std::ostream& stream, const Tensor & tensor_, int64_t linesi
   if(!tensor_.defined()) {
     stream << "[ Tensor (empty) ]";
   } else {
-    Tensor tensor = tensor_.toType(getType(kCPU,kDouble)).contiguous();
+    Type& cpudouble = tensor_.type().toBackend(kCPU).toScalarType(kDouble);
+    Tensor tensor = tensor_.toType(cpudouble).contiguous();
     if(tensor.ndimension() == 0) {
       stream << defaultfloat << tensor.data<double>()[0] << std::endl;
       stream << "[ " << tensor_.pImpl->toString() << "{} ]";

--- a/src/ATen/templates/Type.h
+++ b/src/ATen/templates/Type.h
@@ -63,8 +63,8 @@ struct AT_API Type {
   virtual Tensor unsafeTensorFromTH(void * th_pointer, bool retain) const = 0;
   virtual const char * toString() const = 0;
   virtual std::size_t elementSizeInBytes() const = 0;
-  Type & toBackend(Backend b) const;
-  Type & toScalarType(ScalarType s) const;
+  virtual Type & toBackend(Backend b) const;
+  virtual Type & toScalarType(ScalarType s) const;
 
   // contingious IDs for all types in the system
   // for external dispatch


### PR DESCRIPTION
This allows VariableType override them to return instances of
VariableType. Combined with the change to Formatting.cpp, this lets us
print Variables to std::cout.