### PR TITLE
Adds permute and as_strided to ATen

### DIFF
--- a/src/ATen/Local.cwrap
+++ b/src/ATen/Local.cwrap
@@ -115,6 +115,20 @@
 ]]
 
 [[
+  name: as_strided
+  variants: [method,function]
+  return: argument 0
+  arguments:
+    - arg: THTensor* result
+      output: True
+    - THTensor* self
+    - THSize* size
+    - THStride* stride
+  aten_custom_call: |
+    ${THTensor}_setStorage(${state,}result_->tensor, self_->tensor->storage, self_->tensor->storageOffset, size_, stride_);
+]]
+
+[[
   name: cat
   cname: catArray
   variants: [function]

--- a/src/ATen/test/basic.cpp
+++ b/src/ATen/test/basic.cpp
@@ -125,6 +125,13 @@ static void test(Type & type) {
   }
 
   {
+    Tensor a = type.rand({3, 4, 5});
+    Tensor b = a.permute({1, 2, 0});
+    ASSERT(b.sizes().equals({4, 5, 3}));
+    ASSERT(b.strides().equals({5, 1, 20}));
+  }
+
+  {
     std::cout << "mm:" << std::endl;
     Tensor a = type.rand({3, 4});
     Tensor b = type.rand({4});


### PR DESCRIPTION
Permute transposes multiple dimensions at once. The as_strided function
changes the sizes and strides of a tensor without changing the Storage.
It's a subset of Tensor::set_.