### PR TITLE
Implement expand as a native function.

### DIFF
--- a/src/ATen/Declarations.cwrap
+++ b/src/ATen/Declarations.cwrap
@@ -428,15 +428,6 @@
       long_args: True
 ]]
 [[
-  name: expand
-  cname: newExpand
-  return: THTensor*
-  arguments:
-    - THTensor* self
-    - arg: THSize* size
-      long_args: True
-]]
-[[
   name: resizeAs_
   python_name: resize_as_
   cname: resizeAs

--- a/src/ATen/ExpandUtils.cpp
+++ b/src/ATen/ExpandUtils.cpp
@@ -1,0 +1,72 @@
+#include "ATen/ExpandUtils.h"
+
+namespace at {
+
+std::vector<int64_t> infer_size2(IntList a, IntList b) {
+  auto dimsA = a.size();
+  auto dimsB = b.size();
+  ptrdiff_t ndim = dimsA > dimsB ? dimsA : dimsB;
+  std::vector<int64_t> expandedSizes(ndim);
+
+  for (long i = ndim - 1; i >= 0; --i) {
+    long offset = ndim - 1 - i;
+    long dimA = dimsA - 1 - offset;
+    long dimB = dimsB - 1 - offset;
+    long sizeA = (dimA >= 0) ? a[dimA] : 1;
+    long sizeB = (dimB >= 0) ? b[dimB] : 1;
+    if (sizeA == sizeB || sizeA == 1 || sizeB == 1) {
+      expandedSizes[i] = std::max(sizeA, sizeB);
+    } else {
+      std::ostringstream oss;
+      oss << "The size of tensor a (" << sizeA << ") must match the size of tensor b ("
+          << sizeB << ") at non-singleton dimension " << i;
+      throw std::runtime_error(oss.str());
+    }
+  }
+
+  return expandedSizes;
+}
+
+std::tuple<std::vector<int64_t>, std::vector<int64_t> >
+inferExpandGeometry(const Tensor &tensor, IntList sizes) {
+  int64_t ndim = sizes.size();
+
+  std::vector<int64_t> expandedSizes(ndim);
+  std::vector<int64_t> expandedStrides(ndim);
+
+  // create a new geometry for the tensors
+  for (int64_t i = ndim - 1; i >= 0; --i) {
+    int64_t offset = ndim - 1 - i;
+    int64_t dim = tensor.dim() - 1 - offset;
+    int64_t size = (dim >= 0) ? tensor.sizes()[dim] : 1;
+    int64_t stride = (dim >= 0) ?
+        tensor.strides()[dim] : expandedSizes[i + 1] * expandedStrides[i+1];
+    int64_t targetSize = sizes[i];
+    if (targetSize == -1) {
+      if (dim < 0) {
+        std::ostringstream oss;
+        oss << "The expanded size of the tensor (" << targetSize << ") isn't allowed in a leading, "
+            << "non-existing dimension " << i;
+        throw std::runtime_error(oss.str());
+      } else {
+        targetSize = size;
+      }
+    }
+    if (size != targetSize) {
+      if (size == 1) {
+        size = targetSize;
+        stride = 0;
+      } else {
+        std::ostringstream oss;
+        oss << "The expanded size of the tensor (" << targetSize << ") must match the existing size (" << size 
+            << ") at non-singleton dimension " << i;
+        throw std::runtime_error(oss.str());
+      }
+    }
+    expandedSizes[i] = size;
+    expandedStrides[i] = stride;
+  }
+  return std::tuple<std::vector<int64_t>, std::vector<int64_t>>(expandedSizes, expandedStrides);
+}
+
+}

--- a/src/ATen/ExpandUtils.h
+++ b/src/ATen/ExpandUtils.h
@@ -5,6 +5,9 @@
 
 namespace at {
 
+std::vector<int64_t> infer_size2(IntList a, IntList b);
+std::tuple<std::vector<int64_t>, std::vector<int64_t> > inferExpandGeometry(const Tensor &tensor, IntList sizes);
+
 inline std::tuple<Tensor> expand_inplace(const Tensor &tensor, const Tensor &to_expand) {
   if (tensor.sizes().equals(to_expand.sizes())) {
     return std::make_tuple(to_expand);
@@ -21,31 +24,6 @@ inline std::tuple<Tensor, Tensor> expand_inplace(const Tensor &tensor, const Ten
   return std::make_tuple(to_expand1.expand(tensor.sizes()), to_expand2.expand(tensor.sizes()));
 }
 
-inline std::vector<int64_t> infer_size2(IntList a, IntList b) {
-  auto dimsA = a.size();
-  auto dimsB = b.size();
-  ptrdiff_t ndim = dimsA > dimsB ? dimsA : dimsB;
-  std::vector<int64_t> expandedSizes(ndim);
-
-  for (long i = ndim - 1; i >= 0; --i) {
-    long offset = ndim - 1 - i;
-    long dimA = dimsA - 1 - offset;
-    long dimB = dimsB - 1 - offset;
-    long sizeA = (dimA >= 0) ? a[dimA] : 1;
-    long sizeB = (dimB >= 0) ? b[dimB] : 1;
-    if (sizeA == sizeB || sizeA == 1 || sizeB == 1) {
-      expandedSizes[i] = std::max(sizeA, sizeB);
-    } else {
-      std::ostringstream oss;
-      oss << "The size of tensor a (" << sizeA << ") must match the size of tensor b ("
-          << sizeB << ") at non-singleton dimension " << i;
-      throw std::runtime_error(oss.str());
-    }
-  }
-
-  return expandedSizes;
-}
-
 inline std::tuple<Tensor, Tensor> expand_outplace(const Tensor &to_expand1, const Tensor &to_expand2) {
   if (to_expand1.sizes().equals(to_expand2.sizes())) {
     return std::make_tuple(to_expand1, to_expand2);
@@ -55,9 +33,9 @@ inline std::tuple<Tensor, Tensor> expand_outplace(const Tensor &to_expand1, cons
   return std::make_tuple(to_expand1.expand(expanded_size), to_expand2.expand(expanded_size));
 }
 
-std::tuple<Tensor, Tensor, Tensor> expand_outplace(const Tensor &to_expand1,
-                                                   const Tensor &to_expand2,
-                                                   const Tensor &to_expand3) {
+inline std::tuple<Tensor, Tensor, Tensor> expand_outplace(const Tensor &to_expand1,
+                                                          const Tensor &to_expand2,
+                                                          const Tensor &to_expand3) {
   if (to_expand1.sizes().equals(to_expand2.sizes()) && to_expand1.sizes().equals(to_expand3.sizes())) {
     return std::make_tuple(to_expand1, to_expand2, to_expand3);
   }

--- a/src/ATen/NativeFunctions.h
+++ b/src/ATen/NativeFunctions.h
@@ -2,6 +2,7 @@
 
 #include "ATen/ATen.h"
 #include "ATen/WrapDimUtils.h"
+#include "ATen/ExpandUtils.h"
 #include <vector>
 
 namespace at {
@@ -96,6 +97,30 @@ static inline Tensor permute(const Tensor & self, IntList dims) {
     newStrides[i] = oldStrides[dim];
   }
   return self.as_strided(newSizes, newStrides);
+}
+
+/*
+[NativeFunction]
+name: expand
+arg: Tensor self
+arg: IntList sizes
+return: Tensor
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::expand
+[/NativeFunction]
+*/
+static inline Tensor expand(const Tensor &self, IntList sizes) {
+  if (sizes.size() < (size_t)self.dim()) {
+    throw std::runtime_error("the number of sizes provided must be greater or equal to the "
+                             "number of dimensions in the tensor");
+  }
+
+  std::vector<int64_t> expandedSizes;
+  std::vector<int64_t> expandedStrides;
+  std::tie(expandedSizes, expandedStrides) = inferExpandGeometry(self, sizes);
+
+  return self.as_strided(expandedSizes, expandedStrides);
 }
 
 }


### PR DESCRIPTION
The logic is the same as in TH/THC, but it operates on the sizes
as seen by ATen, rather than TH.  This allows us to change the
sizes representation in ATen independently from TH/THC.