### PR TITLE
warning fix

### DIFF
--- a/src/ATen/function_wrapper.py
+++ b/src/ATen/function_wrapper.py
@@ -318,7 +318,7 @@ def create_generic(top_env, declarations):
             insert({
                 'name': 'output_mask',
                 'type': 'std::array<bool, {}>'.format(mask_size),
-                'default': '{' + ', '.join(['true'] * mask_size) + '}',
+                'default': '{{' + ', '.join(['true'] * mask_size) + '}}',
             })
 
         result = pos_args + kwd_args


### PR DESCRIPTION
clang complains a lot on OSX without these additional braces. @colesbury does this still call the same constructor on std::array?