### PR TITLE
Correct dimensions for reduction functions, squeeze, unsqueeze.

### DIFF
--- a/src/ATen/Declarations.cwrap
+++ b/src/ATen/Declarations.cwrap
@@ -157,7 +157,7 @@
   return: argument 0
   options:
     - cname: set
-      scalar_check: source
+      scalar_check: source_->isScalar()
       arguments:
         - THTensor* self
         - THTensor* source
@@ -331,70 +331,6 @@
     - CONSTANT 1
 ]]
 [[
-  name: squeeze
-  cpu_half: True
-  variants:
-    - method
-    - function
-  return: argument 0
-  options:
-    - arguments:
-        - arg: THTensor* result
-          output: True
-        - THTensor* self
-    - cname: squeeze1d
-      arguments:
-        - arg: THTensor* result
-          output: True
-        - THTensor* self
-        - arg: long dim
-          wrap_dim: self
-]]
-[[
-  name: squeeze_
-  cpu_half: True
-  return: self
-  options:
-    - cname: squeeze
-      arguments:
-        - THTensor* self
-        - THTensor* self
-    - cname: squeeze1d
-      arguments:
-        - THTensor* self
-        - THTensor* self
-        - arg: long dim
-          wrap_dim: self
-]]
-[[
-  name: unsqueeze
-  variants:
-    - method
-    - function
-  cpu_half: True
-  auto_gpu: False
-  return: argument 0
-  cname: unsqueeze1d
-  arguments:
-    - arg: THTensor* result
-      output: True
-    - THTensor* self
-    - arg: long dim
-      wrap_dim: self+1
-]]
-[[
-  name: unsqueeze_
-  cpu_half: True
-  auto_gpu: False
-  return: self
-  cname: unsqueeze1d
-  arguments:
-    - THTensor* self
-    - THTensor* self
-    - arg: long dim
-      wrap_dim: self+1
-]]
-[[
   name: nonzero
   variants:
     - method
@@ -435,7 +371,7 @@
   python_name: resize_as_
   cname: resizeAs
   return: self
-  scalar_check: the_template
+  scalar_check: the_template_->isScalar()
   arguments:
     - THTensor* self
     - THTensor* the_template
@@ -1109,6 +1045,7 @@
       - THTensor* other
     - cname: min
       return: argument 0,1
+      scalar_check: keepdim == false && self_->dim() == 1
       arguments:
         - arg: THTensor* min
           output: True
@@ -1140,6 +1077,7 @@
       - THTensor* other
     - cname: max
       return: argument 0,1
+      scalar_check: keepdim == false && self_->dim() == 1
       arguments:
         - arg: THTensor* max
           output: True
@@ -1159,6 +1097,7 @@
     - method
     - function
   return: argument 0,1
+  scalar_check: keepdim == false && self_->dim() == 1
   arguments:
     - arg: THTensor* values
       output: True
@@ -1178,6 +1117,7 @@
     - method
     - function
   return: argument 0,1
+  scalar_check: keepdim == false && self_->dim() == 1
   arguments:
     - arg: THTensor* values
       output: True
@@ -1202,6 +1142,7 @@
       arguments:
         - THTensor* self
     - cname: median
+      scalar_check: keepdim == false && self_->dim() == 1
       arguments:
         - arg: THTensor* values
           output: True
@@ -2022,6 +1963,7 @@
         - THTensor* self
     - cname: mean
       return: argument 0
+      scalar_check: keepdim == false && self_->dim() == 1
       arguments:
         - arg: THTensor* destination
           output: True
@@ -2052,6 +1994,7 @@
           default: 0
     - cname: var
       return: argument 0
+      scalar_check: keepdim == false && self_->dim() == 1
       arguments:
         - arg: THTensor* destination
           output: True
@@ -2086,6 +2029,7 @@
           default: 0
     - cname: std
       return: argument 0
+      scalar_check: keepdim == false && self_->dim() == 1
       arguments:
         - arg: THTensor* destination
           output: True
@@ -2118,6 +2062,7 @@
           default: AS_REAL(2)
     - cname: norm
       return: argument 0
+      scalar_check: keepdim == false && self_->dim() == 1
       arguments:
         - arg: THTensor* destination
           output: True
@@ -2454,6 +2399,7 @@
         - THTensor* self
     - cname: sum
       return: argument 0
+      scalar_check: keepdim == false && self_->dim() == 1
       arguments:
         - arg: THTensor* result
           output: True
@@ -2475,6 +2421,7 @@
         - THTensor* self
     - cname: prod
       return: argument 0
+      scalar_check: keepdim == false && self_->dim() == 1
       arguments:
         - arg: THTensor* result
           output: True

--- a/src/ATen/Local.cwrap
+++ b/src/ATen/Local.cwrap
@@ -130,6 +130,20 @@
 ]]
 
 [[
+  name: as_strided_
+  variants: [method,function]
+  return: argument 0
+  arguments:
+    - THTensor* self
+    - THSize* size
+    - THStride* stride
+  aten_custom_call: |
+    ${THTensor}_setStorage(${state,}self_->tensor, self_->tensor->storage, self_->tensor->storageOffset, size_, stride_);
+    self_->maybeScalar(size.size() == 0);
+]]
+
+
+[[
   name: cat
   cname: catArray
   variants: [function]

--- a/src/ATen/NativeFunctions.h
+++ b/src/ATen/NativeFunctions.h
@@ -123,5 +123,157 @@ static inline Tensor expand(const Tensor &self, IntList sizes) {
   return self.as_strided(expandedSizes, expandedStrides);
 }
 
+static inline std::tuple<std::vector<int64_t>, std::vector<int64_t> >
+inferSqueezeGeometry(const Tensor &tensor) {
+  std::vector<int64_t> sizes;
+  std::vector<int64_t> strides;
+
+  for(int64_t d = 0; d < tensor.dim(); d++) {
+    if(tensor.sizes()[d] != 1) {
+      sizes.push_back(tensor.sizes()[d]);
+      strides.push_back(tensor.strides()[d]);
+    }
+  }
+
+  return std::make_tuple(sizes, strides);
+}
+
+static inline std::tuple<std::vector<int64_t>, std::vector<int64_t> >
+inferSqueezeGeometry(const Tensor &tensor, int64_t dim) {
+  std::vector<int64_t> sizes;
+  std::vector<int64_t> strides;
+
+  for(int64_t d = 0; d < tensor.dim(); d++) {
+    if(d != dim || tensor.sizes()[dim] != 1) {
+      sizes.push_back(tensor.sizes()[d]);
+      strides.push_back(tensor.strides()[d]);
+    }
+  }
+  return std::make_tuple(sizes, strides);
+}
+
+static inline std::tuple<std::vector<int64_t>, std::vector<int64_t> >
+inferUnsqueezeGeometry(const Tensor &tensor, int64_t dim) {
+  if (tensor.numel() == 0) {
+    throw std::runtime_error("cannot unsqueeze empty tensor");
+  }
+
+  std::vector<int64_t> sizes(tensor.sizes());
+  std::vector<int64_t> strides(tensor.strides());
+  int64_t new_stride = dim >= tensor.dim() - 1 ? 1 : sizes[dim] * strides[dim];
+  sizes.insert(sizes.begin() + dim, 1);
+  strides.insert(strides.begin() + dim, new_stride);
+
+  return std::make_tuple(sizes, strides);
+}
+
+/*
+[NativeFunction]
+name: squeeze
+arg: Tensor self
+return: Tensor
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::squeeze
+[/NativeFunction]
+*/
+static inline Tensor squeeze(const Tensor & self) {
+  auto g = inferSqueezeGeometry(self);
+  return self.as_strided(std::get<0>(g), std::get<1>(g));
+}
+
+/*
+[NativeFunction]
+name: squeeze
+arg: Tensor self
+arg: int64_t dim
+return: Tensor
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::squeeze
+[/NativeFunction]
+*/
+static inline Tensor squeeze(const Tensor & self, int64_t dim) {
+  dim = maybe_wrap_dim(dim, self.dim());
+
+  if (self.sizes()[dim] != 1) {
+    return self.as_strided(self.sizes().vec(), self.strides().vec());
+  }
+  auto g = inferSqueezeGeometry(self, dim);
+  return self.as_strided(std::get<0>(g), std::get<1>(g));
+}
+
+/*
+[NativeFunction]
+name: squeeze_
+arg: Tensor self
+return: Tensor
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::squeeze_
+[/NativeFunction]
+*/
+static inline Tensor squeeze_(Tensor self) {
+  auto g = inferSqueezeGeometry(self);
+  return self.as_strided_(std::get<0>(g), std::get<1>(g));
+}
+
+/*
+[NativeFunction]
+name: squeeze_
+arg: Tensor self
+arg: int64_t dim
+return: Tensor
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::squeeze_
+[/NativeFunction]
+*/
+static inline Tensor squeeze_(Tensor self, int64_t dim) {
+  dim = maybe_wrap_dim(dim, self.dim());
+
+  if (self.sizes()[dim] != 1) {
+    return self.as_strided_(self.sizes().vec(), self.strides().vec());
+  }
+  auto g = inferSqueezeGeometry(self, dim);
+  return self.as_strided_(std::get<0>(g), std::get<1>(g));
+}
+
+/*
+[NativeFunction]
+name: unsqueeze
+arg: Tensor self
+arg: int64_t dim
+return: Tensor
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::unsqueeze
+[/NativeFunction]
+*/
+static inline Tensor unsqueeze(const Tensor & self, int64_t dim) {
+  dim = maybe_wrap_dim(dim, self.dim() + 1);
+
+  auto g = inferUnsqueezeGeometry(self, dim);
+  return self.as_strided(std::get<0>(g), std::get<1>(g));
+}
+
+/*
+[NativeFunction]
+name: unsqueeze_
+arg: Tensor self
+arg: int64_t dim
+return: Tensor
+variants: method, function
+type_method_definition_level: base
+type_method_definition_dispatch: at::native::unsqueeze_
+[/NativeFunction]
+*/
+static inline Tensor unsqueeze_(Tensor self, int64_t dim) {
+  dim = maybe_wrap_dim(dim, self.dim() + 1);
+
+  auto g = inferUnsqueezeGeometry(self, dim);
+  return self.as_strided_(std::get<0>(g), std::get<1>(g));
+}
+
 }
 }

--- a/src/ATen/WrapDimUtils.h
+++ b/src/ATen/WrapDimUtils.h
@@ -21,16 +21,16 @@ static inline int64_t maybe_wrap_dim(int64_t dim, int64_t dim_post_expr) {
   return dim;
 }
 
-static inline int64_t maybe_wrap_dim(int64_t dim, TensorImpl *tensor, int64_t to_add) {
-  return maybe_wrap_dim(dim, tensor->dim() + to_add);
+static inline int64_t maybe_wrap_dim(int64_t dim, TensorImpl *tensor) {
+  return maybe_wrap_dim(dim, tensor->dim());
 }
 
-static inline int64_t maybe_wrap_dim(int64_t dim, TensorList tensors, int64_t to_add) {
+static inline int64_t maybe_wrap_dim(int64_t dim, TensorList tensors) {
   if (tensors.size() == 0) {
     // can't wrap empty TensorList; rely on underlying implementation to throw error if necessary.
     return dim;
   }
-  return maybe_wrap_dim(dim, tensors[0].dim() + to_add);
+  return maybe_wrap_dim(dim, tensors[0].dim());
 }
 
 }


### PR DESCRIPTION
Reduction functions that take a dimension now properly reduce
down to scalars if passed a 1-dimensional tensor.

Squeeze now properly reduces down to scalars as well (and is implemented
as a native function).

Unsqueeze now handles scalar inputs correctly (so unsqueezing a scalar
returns a dim 1 tensor, rather than a dim 2 tensor).